### PR TITLE
feat: expanded SAST rule sets for 5 frameworks (PLAN-16)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,4 @@ dist/
 .github/copilot-instructions.md
 .gitlab-ci.yml
 resume/
+rules/*/tests/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -265,6 +265,23 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
+      - name: Build local standard image for rule fixture tests
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./images/Dockerfile
+          push: false
+          load: true
+          tags: ez-appsec:standard-rule-test
+          cache-from: type=gha
+          platforms: linux/amd64
+
+      - name: Run rule fixture tests in standard image
+        run: |
+          docker run --rm --entrypoint python3 \
+            -v "$PWD:/workspace:ro" -w /workspace \
+            ez-appsec:standard-rule-test scripts/verify-rule-fixtures.py
+
       - name: Test image functionality
         if: github.event_name != 'pull_request'
         run: |
@@ -319,6 +336,23 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
+      - name: Build local slim image for rule fixture tests
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./images/Dockerfile.slim
+          push: false
+          load: true
+          tags: ez-appsec:slim-rule-test
+          cache-from: type=gha
+          platforms: linux/amd64
+
+      - name: Run rule fixture tests in slim image
+        run: |
+          docker run --rm --entrypoint python3 \
+            -v "$PWD:/workspace:ro" -w /workspace \
+            ez-appsec:slim-rule-test scripts/verify-rule-fixtures.py
+
   build-docker-micro:
     name: Build Micro Docker Image
     runs-on: ubuntu-latest
@@ -366,6 +400,87 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
+      - name: Build local micro image for rule fixture tests
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./images/Dockerfile.micro
+          push: false
+          load: true
+          tags: ez-appsec:micro-rule-test
+          cache-from: type=gha
+          platforms: linux/amd64
+
+      - name: Verify micro image intentionally skips rule fixture tests
+        run: |
+          docker run --rm --entrypoint python3 \
+            -v "$PWD:/workspace:ro" -w /workspace \
+            ez-appsec:micro-rule-test scripts/verify-rule-fixtures.py --allow-missing-semgrep
+
+  build-docker-thin:
+    name: Build Thin Docker Image
+    runs-on: ubuntu-latest
+    needs: [lint-python, test-unit]
+    outputs:
+      image-tag: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch,suffix=-thin
+            type=ref,event=pr,suffix=-thin
+            type=semver,pattern={{version}},suffix=-thin
+            type=semver,pattern={{major}}.{{minor}},suffix=-thin
+            type=sha,prefix=,suffix=-thin
+            type=raw,value=thin,enable={{is_default_branch}}
+
+      - name: Build and push thin image
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./images/Dockerfile.thin
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build local thin image for rule fixture tests
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./images/Dockerfile.thin
+          push: false
+          load: true
+          tags: ez-appsec:thin-rule-test
+          cache-from: type=gha
+          platforms: linux/amd64
+
+      - name: Run rule fixture tests in thin image
+        run: |
+          docker run --rm --entrypoint python3 \
+            -v "$PWD:/workspace:ro" -w /workspace \
+            ez-appsec:thin-rule-test scripts/verify-rule-fixtures.py
+
   build-docker-semgrep:
     name: Build Semgrep Docker Image
     runs-on: ubuntu-latest
@@ -412,6 +527,23 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+      - name: Build local semgrep image for rule fixture tests
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./images/Dockerfile.semgrep
+          push: false
+          load: true
+          tags: ez-appsec:semgrep-rule-test
+          cache-from: type=gha
+          platforms: linux/amd64
+
+      - name: Run rule fixture tests in semgrep image
+        run: |
+          docker run --rm --entrypoint python3 \
+            -v "$PWD:/workspace:ro" -w /workspace \
+            ez-appsec:semgrep-rule-test scripts/verify-rule-fixtures.py
 
   set-package-public:
     name: Set Package Visibility to Public

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,60 @@ jobs:
             images/Dockerfile.semgrep
         continue-on-error: true
 
+  lint-rule-fixtures:
+    name: Lint Rule Fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install language runtimes
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ruby php-cli
+          # node is preinstalled on ubuntu-latest
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install semgrep and pytest
+        run: |
+          pip install --no-cache-dir semgrep pyyaml pytest
+
+      - name: Syntax-check Ruby fixtures
+        run: |
+          echo "🔍 Checking Ruby fixture syntax (ruby -c)..."
+          fail=0
+          for f in rules/*/tests/*.rb; do
+            if ! ruby -c "$f" >/dev/null; then echo "  FAIL $f"; fail=1; fi
+          done
+          exit $fail
+
+      - name: Syntax-check PHP fixtures
+        run: |
+          echo "🔍 Checking PHP fixture syntax (php -l)..."
+          fail=0
+          for f in rules/*/tests/*.php; do
+            if ! php -l "$f" >/dev/null 2>&1; then echo "  FAIL $f"; php -l "$f"; fail=1; fi
+          done
+          exit $fail
+
+      - name: Syntax-check JavaScript fixtures
+        run: |
+          echo "🔍 Checking JavaScript fixture syntax (node --check)..."
+          fail=0
+          for f in rules/*/tests/*.js; do
+            if ! node --check "$f" 2>/dev/null; then echo "  FAIL $f"; node --check "$f"; fail=1; fi
+          done
+          exit $fail
+
+      - name: Run semgrep rule fixture tests
+        run: |
+          echo "🧪 Verifying each rule fires on its TP and is clean on its TN..."
+          pytest tests/test_rule_fixtures.py -q
+
   # ============================================
   # TEST STAGE
   # ============================================

--- a/.github/workflows/github-scan.yml
+++ b/.github/workflows/github-scan.yml
@@ -29,20 +29,48 @@ jobs:
     continue-on-error: true
     steps:
       - name: Check for newer ez-appsec release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CURRENT_VERSION: ${{ vars.EZ_APPSEC_VERSION || 'latest' }}
         run: |
-          LATEST=$(curl -sSf \
-            -H "Accept: application/vnd.github+json" \
-            -H "User-Agent: ez-appsec-version-check/1.0" \
-            https://api.github.com/repos/ez-appsec/ez-appsec/releases/latest \
-            | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'].lstrip('v'))")
-          CURRENT="${{ vars.EZ_APPSEC_VERSION || 'latest' }}"
-          if [ "$CURRENT" = "latest" ]; then
-            echo "::warning::ez-appsec: using 'latest' image tag. Pin EZ_APPSEC_VERSION to a specific version for reproducible scans. Current release: ${LATEST}"
-          elif [ "$CURRENT" != "$LATEST" ]; then
-            echo "::warning::ez-appsec ${CURRENT} is outdated. Latest release: ${LATEST}. Update the EZ_APPSEC_VERSION variable."
-          else
-            echo "ez-appsec ${CURRENT} is up to date."
-          fi
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
+
+          current = os.environ.get("CURRENT_VERSION", "latest")
+          req = urllib.request.Request(
+              "https://api.github.com/repos/ez-appsec/ez-appsec/releases/latest",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "User-Agent": "ez-appsec-version-check/1.0",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          try:
+              with urllib.request.urlopen(req, timeout=15) as response:
+                  latest = json.load(response)["tag_name"].lstrip("v")
+          except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, KeyError, json.JSONDecodeError) as exc:
+              print(f"::notice::ez-appsec version check skipped: could not fetch latest release ({exc})")
+              sys.exit(0)
+
+          if current == "latest":
+              print(
+                  "::warning::ez-appsec: using 'latest' image tag. "
+                  "Pin EZ_APPSEC_VERSION to a specific version for reproducible scans. "
+                  f"Current release: {latest}"
+              )
+          elif current != latest:
+              print(
+                  f"::warning::ez-appsec {current} is outdated. Latest release: {latest}. "
+                  "Update the EZ_APPSEC_VERSION variable."
+              )
+          else:
+              print(f"ez-appsec {current} is up to date.")
+          PY
 
   scan:
     name: Security Scan

--- a/ez_appsec/cli.py
+++ b/ez_appsec/cli.py
@@ -42,7 +42,8 @@ def main():
 @click.option("--license-check", is_flag=True, default=False, help="Run license compliance check (requires syft)")
 @click.option("--image", default=None, help="Container image to scan for OS-level CVEs (e.g. nginx:latest)")
 @click.option("--registry-auth", default=None, help="Private registry credentials in user:token format")
-def scan(path, ai_prompt, languages, severity, output, config_file, baseline_path, baseline_threshold, slack_webhook, teams_webhook, project_name, dashboard_url, jira_url, jira_email, jira_token, jira_project, sbom, sbom_output, license_check, image, registry_auth):
+@click.option("--rules", multiple=True, help="Custom rule packs to enable (python, ruby, java, javascript, php, or 'all')")
+def scan(path, ai_prompt, languages, severity, output, config_file, baseline_path, baseline_threshold, slack_webhook, teams_webhook, project_name, dashboard_url, jira_url, jira_email, jira_token, jira_project, sbom, sbom_output, license_check, image, registry_auth, rules):
     """Scan a codebase for security vulnerabilities using AI analysis
 
     PATH: Directory or file to scan (default: current directory)
@@ -57,6 +58,13 @@ def scan(path, ai_prompt, languages, severity, output, config_file, baseline_pat
             config.output_file = output
 
         scanner = SecurityScanner(config, license_check=license_check)
+
+        if rules and scanner.external:
+            from ez_appsec.external_scanners import resolve_rules_dirs
+            extra_dirs = resolve_rules_dirs(list(rules))
+            if extra_dirs and "semgrep" in scanner.external.scanners:
+                scanner.external.scanners["semgrep"].extra_rules_dirs = extra_dirs
+                click.echo(f"  Custom rules: {', '.join(rules)} ({len(extra_dirs)} pack(s))")
         results = scanner.scan(path, ai_prompt)
 
         if image:

--- a/ez_appsec/external_scanners.py
+++ b/ez_appsec/external_scanners.py
@@ -850,7 +850,15 @@ class GrypeScanner(ScannerWrapper):
                 if cmd is None:
                     return
                 logger.info(f"Generating dependency manifest via: {' '.join(cmd)}")
-                result = subprocess.run(cmd, capture_output=True, text=True, cwd=path, timeout=300)
+                try:
+                    result = subprocess.run(cmd, capture_output=True, text=True, cwd=path, timeout=300)
+                except FileNotFoundError:
+                    logger.warning(
+                        "Dependency manifest generation skipped: %s is not installed. "
+                        "Commit a lockfile/SBOM or use the standard image for automatic dependency installation.",
+                        cmd[0],
+                    )
+                    return
                 if result.returncode != 0:
                     logger.warning(f"Dependency manifest generation failed: {result.stderr[:200]}")
                 return

--- a/ez_appsec/external_scanners.py
+++ b/ez_appsec/external_scanners.py
@@ -160,8 +160,52 @@ class GitleaksScanner(ScannerWrapper):
             return [], raw_output_path
 
 
+RULES_LANGUAGE_MAP = {
+    "python": "python",
+    "ruby": "ruby",
+    "java": "java",
+    "javascript": "javascript",
+    "js": "javascript",
+    "typescript": "javascript",
+    "ts": "javascript",
+    "php": "php",
+    "laravel": "php",
+    "django": "python",
+    "rails": "ruby",
+    "spring": "java",
+    "express": "javascript",
+}
+
+
+def resolve_rules_dirs(language_names: List[str]) -> List[str]:
+    """Map language/framework names to rule directory paths."""
+    package_rules = Path(__file__).parent.parent / "rules"
+    docker_rules = Path("/app/rules")
+    rules_root = package_rules if package_rules.is_dir() else docker_rules
+
+    dirs: List[str] = []
+    for name in language_names:
+        key = name.lower()
+        if key == "all":
+            for lang_dir in sorted(rules_root.iterdir()):
+                if lang_dir.is_dir() and not lang_dir.name.startswith("."):
+                    dirs.append(str(lang_dir))
+            break
+        mapped = RULES_LANGUAGE_MAP.get(key, key)
+        candidate = rules_root / mapped
+        if candidate.is_dir():
+            dirs.append(str(candidate))
+        else:
+            logger.warning(f"No rule pack found for '{name}' (looked in {candidate})")
+    return dirs
+
+
 class SemgrepScanner(ScannerWrapper):
     """Wrapper for semgrep SAST analysis"""
+
+    def __init__(self, enabled: bool = True, extra_rules_dirs: Optional[List[str]] = None):
+        super().__init__(enabled)
+        self.extra_rules_dirs = extra_rules_dirs or []
 
     def _add_ai_remediation_fields(
         self,
@@ -311,6 +355,11 @@ class SemgrepScanner(ScannerWrapper):
 
             if not config_flags:
                 config_flags = ["--config=p/security-audit"]
+
+            for rules_dir in self.extra_rules_dirs:
+                if os.path.isdir(rules_dir):
+                    config_flags.append(f"--config={rules_dir}")
+                    logger.info(f"Using custom rule pack from {rules_dir}")
 
             result = subprocess.run(
                 ["semgrep"] + config_flags + ["--json", "--output", raw_output_path, path],

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -89,13 +89,16 @@ ENV PATH="/usr/local/bin:/usr/bin:/bin:$PATH" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
+# Copy custom SAST rule packs
+COPY rules/ /app/rules/
+
 # Copy website files
 COPY web/ /web/
 
 # Create non-root user for runtime
 RUN addgroup -S ezappsec && adduser -S -G ezappsec ezappsec && \
     mkdir -p /scan /home/ezappsec/.cache && \
-    chown -R ezappsec:ezappsec /web /home/ezappsec /scan
+    chown -R ezappsec:ezappsec /web /app/rules /home/ezappsec /scan
 
 USER ezappsec
 ENV HOME=/home/ezappsec

--- a/images/Dockerfile.thin
+++ b/images/Dockerfile.thin
@@ -1,8 +1,14 @@
-# Pull kics binary from official image
-FROM checkmarx/kics@sha256:3e5a268eb8adda2e5a483c9359ddfc4cd520ab856a7076dc0b1d8784a37e2602 as kics
+# Thin ez-appsec image: standard scanners, no runtime package managers.
+#
+# Tradeoff: grype dependency discovery will not auto-run npm/pip for projects
+# that only have package.json or requirements.txt. Commit lockfiles/SBOMs, or
+# use the standard image when automatic dependency installation is required.
 
-# Multi-stage build for minimal image size (pinned versions to satisfy hadolint)
-FROM python:3.11.9-alpine3.18 as builder
+# Pull kics binary from official image
+FROM checkmarx/kics@sha256:3e5a268eb8adda2e5a483c9359ddfc4cd520ab856a7076dc0b1d8784a37e2602 AS kics
+
+# Multi-stage build for minimal image size (pinned versions match standard image where possible)
+FROM python:3.11.9-alpine3.18 AS builder
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
@@ -14,11 +20,9 @@ RUN apk add --no-cache \
     git=2.40.4-r0
 
 WORKDIR /app
-
 COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy and build wheel
 COPY . /app
 RUN pip install --no-cache-dir build==1.4.0 && python -m build --wheel --outdir /dist
 
@@ -30,7 +34,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1
 
-# Install runtime dependencies (pinned versions)
+# No nodejs/npm in thin image. Keep pip only long enough to install runtime deps,
+# then remove it before the final image layer.
 RUN apk add --no-cache \
     python3=3.11.12-r1 \
     git=2.40.4-r0 \
@@ -39,9 +44,7 @@ RUN apk add --no-cache \
     bash=5.2.15-r5 \
     ca-certificates=20241121-r1 \
     libffi=3.4.4-r2 \
-    openssl=3.1.8-r0 \
-    nodejs=18.20.1-r0 \
-    npm=9.6.6-r0 && \
+    openssl=3.1.8-r0 && \
     python3 -m ensurepip && \
     python3 -m pip install --no-cache-dir --upgrade pip==26.0.1
 
@@ -62,11 +65,9 @@ RUN ARCH=$(uname -m) && \
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin && \
     grype version
 
-# semgrep via pip (pinned)
 RUN pip install --no-cache-dir semgrep==1.157.0 && \
     semgrep --version && \
-    find /usr/lib/python3.11/site-packages -depth -type d -name __pycache__ -exec rm -rf {} + && \
-    rm -rf /usr/lib/python3.11/ensurepip
+    find /usr/lib/python3.11/site-packages -depth -type d -name __pycache__ -exec rm -rf {} +
 
 # Bundle GitLab SAST rules (language dirs only — offline use, richer severity metadata)
 RUN curl -sSfL "https://gitlab.com/gitlab-org/security-products/sast-rules/-/archive/main/sast-rules-main.tar.gz" \
@@ -79,41 +80,34 @@ RUN curl -sSfL "https://gitlab.com/gitlab-org/security-products/sast-rules/-/arc
     rm -rf /tmp/sast-rules.tar.gz /tmp/sast-rules-extract && \
     curl -sSfL "https://semgrep.dev/c/p/ruby" -o /usr/local/share/sast-rules/ruby.yml
 
-# Copy kics binary and assets from official image
 COPY --from=kics /app/bin/kics /usr/local/bin/kics
 COPY --from=kics /app/bin/assets /usr/local/bin/assets
 RUN kics version
 
-# Install ez-appsec wheel and dependencies from builder
 COPY --from=builder /dist/*.whl /tmp/
 COPY --from=builder /app/requirements.txt /tmp/
 RUN pip install --no-cache-dir -r /tmp/requirements.txt /tmp/*.whl && \
     rm /tmp/*.whl /tmp/requirements.txt && \
     find /usr/lib/python3.11/site-packages -depth -type d -name __pycache__ -exec rm -rf {} + && \
-    rm -rf /usr/lib/python3.11/ensurepip
+    rm -rf /usr/lib/python3.11/ensurepip \
+           /usr/lib/python3.11/site-packages/pip \
+           /usr/lib/python3.11/site-packages/pip-* \
+           /usr/bin/pip* /usr/local/bin/pip*
 
-ENV PATH="/usr/local/bin:/usr/bin:/bin:$PATH"
+ENV PATH="/usr/local/bin:/usr/bin:/bin:$PATH" \
+    EZ_APPSEC_THIN_IMAGE=1
 
-# Copy custom SAST rule packs
 COPY rules/ /app/rules/
-
-# Copy website files
 COPY web/ /web/
 
-# Create non-root user for runtime
 RUN addgroup -S ezappsec && adduser -S -G ezappsec ezappsec && \
     mkdir -p /scan /home/ezappsec/.cache && \
     chown -R ezappsec:ezappsec /web /app/rules /home/ezappsec /scan
 
 USER ezappsec
+WORKDIR /scan
 ENV HOME=/home/ezappsec
 
-WORKDIR /scan
-
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD ez-appsec --version || exit 1
-
-# Default command
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 CMD ez-appsec --version || exit 1
 ENTRYPOINT ["ez-appsec"]
 CMD ["--help"]

--- a/images/build-docker.sh
+++ b/images/build-docker.sh
@@ -17,14 +17,22 @@ docker build -f images/Dockerfile.slim -t ez-appsec:slim .
 SLIM_SIZE=$(docker images ez-appsec:slim --format "{{.Size}}")
 echo "✓ Slim image size: $SLIM_SIZE"
 
+# Build thin image
+echo "📦 Building thin image (ez-appsec:thin)..."
+docker build -f images/Dockerfile.thin -t ez-appsec:thin .
+THIN_SIZE=$(docker images ez-appsec:thin --format "{{.Size}}")
+echo "✓ Thin image size: $THIN_SIZE"
+
 # Test images
 echo "🧪 Testing images..."
 docker run --rm ez-appsec:latest --version
 docker run --rm ez-appsec:slim --version
+docker run --rm ez-appsec:thin --version
 
 echo "✓ Testing scanner availability..."
 docker run --rm ez-appsec:latest status
 docker run --rm ez-appsec:slim status
+docker run --rm ez-appsec:thin status
 echo "🧪 Testing individual scanners..."
 docker run --rm ez-appsec:latest gitleaks version
 docker run --rm ez-appsec:latest semgrep --version
@@ -36,7 +44,9 @@ echo ""
 echo "Image Summary:"
 echo "  Standard: $STANDARD_SIZE (ez-appsec:latest)"
 echo "  Slim:     $SLIM_SIZE (ez-appsec:slim)"
+echo "  Thin:     $THIN_SIZE (ez-appsec:thin)"
 echo ""
 echo "Usage:"
 echo "  docker run --rm -v \$(pwd):/scan ez-appsec:latest scan ."
 echo "  docker run --rm -v \$(pwd):/scan ez-appsec:slim scan ."
+echo "  docker run --rm -v \$(pwd):/scan ez-appsec:thin scan ."

--- a/rules/java/spring-csrf-disable.yaml
+++ b/rules/java/spring-csrf-disable.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: ez-spring-csrf-disable
+    message: >-
+      CSRF protection is explicitly disabled via csrf().disable(). This allows
+      cross-site request forgery attacks. For REST APIs using token-based auth,
+      this may be acceptable, but for session-based web apps it is dangerous.
+    severity: WARNING
+    languages: [java]
+    metadata:
+      cwe: "CWE-352"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: http.csrf().disable()
+      - pattern: http.csrf(csrf -> csrf.disable())
+      - pattern: $HTTP.csrf(AbstractHttpConfigurer::disable)

--- a/rules/java/spring-header-injection.yaml
+++ b/rules/java/spring-header-injection.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: ez-spring-header-injection
+    message: >-
+      User input from request parameter or header is placed directly into a
+      response header. An attacker can inject CRLF characters to add arbitrary
+      headers or split the HTTP response.
+    severity: ERROR
+    languages: [java]
+    metadata:
+      cwe: "CWE-113"
+      owasp: "A03:2021 Injection"
+      category: security
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: |
+          $VAL = $REQ.getParameter(...);
+          ...
+          $RESP.setHeader($NAME, $VAL);
+      - pattern: |
+          $VAL = $REQ.getParameter(...);
+          ...
+          $RESP.addHeader($NAME, $VAL);
+      - pattern: |
+          $VAL = $REQ.getHeader(...);
+          ...
+          $RESP.setHeader($NAME, $VAL);

--- a/rules/java/spring-idor.yaml
+++ b/rules/java/spring-idor.yaml
@@ -1,0 +1,24 @@
+rules:
+  - id: ez-spring-idor-path-variable
+    message: >-
+      Direct use of @PathVariable ID to look up a record without verifying
+      the current user owns it. This allows IDOR — attackers can access other
+      users' data by changing the ID in the URL.
+    severity: ERROR
+    languages: [java]
+    metadata:
+      cwe: "CWE-639"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: MEDIUM
+    patterns:
+      - pattern: |
+          $REPO.findById($ID)
+      - pattern-inside: |
+          public $RET $METHOD(@PathVariable $TYPE $ID, ...) {
+              ...
+          }
+      - pattern-not-inside: |
+          if (...$ID...equals(...$USER...)) {
+              ...
+          }

--- a/rules/java/spring-idor.yaml
+++ b/rules/java/spring-idor.yaml
@@ -12,13 +12,18 @@ rules:
       category: security
       confidence: MEDIUM
     patterns:
-      - pattern: |
-          $REPO.findById($ID)
+      - pattern: $REPO.findById($ID)
       - pattern-inside: |
           public $RET $METHOD(@PathVariable $TYPE $ID, ...) {
               ...
           }
+      # Exclude methods that perform an ownership check against the principal.
+      # The check typically reads getOwnerId().equals(principal.getName()).
       - pattern-not-inside: |
-          if (...$ID...equals(...$USER...)) {
+          public $RET $METHOD(@PathVariable $TYPE $ID, ...) {
+              ...
+              if ($ENT.getOwnerId().equals($PRINC.getName())) {
+                  ...
+              }
               ...
           }

--- a/rules/java/spring-insecure-deserialization.yaml
+++ b/rules/java/spring-insecure-deserialization.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: ez-spring-insecure-deserialization
+    message: >-
+      Deserializing untrusted data with ObjectInputStream allows arbitrary code
+      execution. An attacker can craft a serialized Java object that executes
+      arbitrary commands when deserialized.
+    severity: ERROR
+    languages: [java]
+    metadata:
+      cwe: "CWE-502"
+      owasp: "A08:2021 Software and Data Integrity Failures"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: new ObjectInputStream($REQ.getInputStream())
+      - pattern: |
+          ObjectInputStream $OIS = new ObjectInputStream(...);
+          ...
+          $OIS.readObject();
+      - pattern: new ObjectInputStream(new ByteArrayInputStream($DATA))

--- a/rules/java/spring-mass-assignment.yaml
+++ b/rules/java/spring-mass-assignment.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: ez-spring-mass-assignment
+    message: >-
+      Binding request parameters directly to a JPA entity without @ModelAttribute
+      allow-listing or a DTO. An attacker can set sensitive fields like role or
+      isAdmin by adding unexpected request parameters. Use a DTO or explicit
+      @InitBinder with setAllowedFields.
+    severity: ERROR
+    languages: [java]
+    metadata:
+      cwe: "CWE-915"
+      owasp: "A04:2021 Insecure Design"
+      category: security
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: |
+          public $RET $METHOD(@ModelAttribute $ENTITY $VAR, ...) {
+              ...
+              $REPO.save($VAR);
+              ...
+          }
+      - pattern: |
+          public $RET $METHOD($ENTITY $VAR, ...) {
+              ...
+              $REPO.save($VAR);
+              ...
+          }

--- a/rules/java/tests/test_csrf_disable_tn.java
+++ b/rules/java/tests/test_csrf_disable_tn.java
@@ -1,0 +1,13 @@
+// True negative: CSRF enabled (default, safe)
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    // ok: ez-spring-csrf-disable
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+            .anyRequest().authenticated()
+            .and()
+            .formLogin();
+    }
+}

--- a/rules/java/tests/test_csrf_disable_tp.java
+++ b/rules/java/tests/test_csrf_disable_tp.java
@@ -1,0 +1,12 @@
+// True positive: CSRF protection explicitly disabled
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        // ruleid: ez-spring-csrf-disable
+        http.csrf().disable()
+            .authorizeRequests()
+            .anyRequest().authenticated();
+    }
+}

--- a/rules/java/tests/test_deserialization_tn.java
+++ b/rules/java/tests/test_deserialization_tn.java
@@ -1,0 +1,11 @@
+// True negative: Jackson JSON deserialization (safe)
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.servlet.http.HttpServletRequest;
+
+public class DataImporter {
+    public MyDto importData(HttpServletRequest req) throws Exception {
+        // ok: ez-spring-insecure-deserialization
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(req.getInputStream(), MyDto.class);
+    }
+}

--- a/rules/java/tests/test_deserialization_tp.java
+++ b/rules/java/tests/test_deserialization_tp.java
@@ -1,0 +1,11 @@
+// True positive: ObjectInputStream from request
+import java.io.ObjectInputStream;
+import javax.servlet.http.HttpServletRequest;
+
+public class DataImporter {
+    public Object importData(HttpServletRequest req) throws Exception {
+        // ruleid: ez-spring-insecure-deserialization
+        ObjectInputStream ois = new ObjectInputStream(req.getInputStream());
+        return ois.readObject();
+    }
+}

--- a/rules/java/tests/test_header_injection_tn.java
+++ b/rules/java/tests/test_header_injection_tn.java
@@ -1,0 +1,10 @@
+// True negative: hardcoded header value (safe)
+@Controller
+public class LanguageController {
+
+    @GetMapping("/set-lang")
+    // ok: ez-spring-header-injection
+    public void setLang(HttpServletResponse resp) {
+        resp.setHeader("Content-Language", "en-US");
+    }
+}

--- a/rules/java/tests/test_header_injection_tp.java
+++ b/rules/java/tests/test_header_injection_tp.java
@@ -1,0 +1,11 @@
+// True positive: user input in response header
+@Controller
+public class LanguageController {
+
+    @GetMapping("/set-lang")
+    public void setLang(HttpServletRequest req, HttpServletResponse resp) {
+        // ruleid: ez-spring-header-injection
+        String lang = req.getParameter("lang");
+        resp.setHeader("Content-Language", lang);
+    }
+}

--- a/rules/java/tests/test_idor_tn.java
+++ b/rules/java/tests/test_idor_tn.java
@@ -1,0 +1,17 @@
+// True negative: scoped to current user (safe)
+@RestController
+public class InvoiceController {
+
+    @Autowired
+    private InvoiceRepository invoiceRepo;
+
+    @GetMapping("/invoice/{id}")
+    // ok: ez-spring-idor-path-variable
+    public Invoice getInvoice(@PathVariable Long id, Principal principal) {
+        Invoice invoice = invoiceRepo.findById(id).orElseThrow();
+        if (invoice.getOwnerId().equals(principal.getName())) {
+            return invoice;
+        }
+        throw new AccessDeniedException("Not your invoice");
+    }
+}

--- a/rules/java/tests/test_idor_tp.java
+++ b/rules/java/tests/test_idor_tp.java
@@ -1,0 +1,13 @@
+// True positive: IDOR via direct findById without ownership check
+@RestController
+public class InvoiceController {
+
+    @Autowired
+    private InvoiceRepository invoiceRepo;
+
+    @GetMapping("/invoice/{id}")
+    public Invoice getInvoice(@PathVariable Long id) {
+        // ruleid: ez-spring-idor-path-variable
+        return invoiceRepo.findById(id).orElseThrow();
+    }
+}

--- a/rules/java/tests/test_mass_assignment_tn.java
+++ b/rules/java/tests/test_mass_assignment_tn.java
@@ -1,0 +1,16 @@
+// True negative: DTO with explicit field mapping (safe)
+@RestController
+public class UserController {
+
+    @Autowired
+    private UserRepository userRepo;
+
+    @PostMapping("/users")
+    // ok: ez-spring-mass-assignment
+    public User createUser(@RequestBody CreateUserDto dto) {
+        User user = new User();
+        user.setName(dto.getName());
+        user.setEmail(dto.getEmail());
+        return userRepo.save(user);
+    }
+}

--- a/rules/java/tests/test_mass_assignment_tp.java
+++ b/rules/java/tests/test_mass_assignment_tp.java
@@ -1,0 +1,13 @@
+// True positive: entity bound directly from request
+@RestController
+public class UserController {
+
+    @Autowired
+    private UserRepository userRepo;
+
+    @PostMapping("/users")
+    // ruleid: ez-spring-mass-assignment
+    public User createUser(@ModelAttribute User user) {
+        return userRepo.save(user);
+    }
+}

--- a/rules/javascript/express-csrf-missing.yaml
+++ b/rules/javascript/express-csrf-missing.yaml
@@ -1,0 +1,30 @@
+rules:
+  - id: ez-express-no-csrf
+    message: >-
+      Express POST/PUT/DELETE route without CSRF middleware. If this app uses
+      cookies or sessions, state-changing endpoints need CSRF protection. Use
+      the csurf or csrf-csrf middleware, or use token-based auth instead.
+    severity: WARNING
+    languages: [javascript, typescript]
+    metadata:
+      cwe: "CWE-352"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: LOW
+    pattern-either:
+      - pattern: |
+          app.post($PATH, function($REQ, $RES) {
+              ...
+          })
+      - pattern: |
+          app.put($PATH, function($REQ, $RES) {
+              ...
+          })
+      - pattern: |
+          app.delete($PATH, function($REQ, $RES) {
+              ...
+          })
+      - pattern: |
+          router.post($PATH, function($REQ, $RES) {
+              ...
+          })

--- a/rules/javascript/express-header-injection.yaml
+++ b/rules/javascript/express-header-injection.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: ez-express-header-injection
+    message: >-
+      User input from request query, params, or body is used directly in a
+      response header. An attacker can inject CRLF characters to add arbitrary
+      headers or split the HTTP response.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      cwe: "CWE-113"
+      owasp: "A03:2021 Injection"
+      category: security
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: $RES.setHeader($NAME, req.query.$KEY)
+      - pattern: $RES.setHeader($NAME, req.params.$KEY)
+      - pattern: $RES.setHeader($NAME, req.body.$KEY)
+      - pattern: $RES.set($NAME, req.query.$KEY)
+      - pattern: $RES.set($NAME, req.params.$KEY)
+      - pattern: $RES.header($NAME, req.query.$KEY)

--- a/rules/javascript/express-idor.yaml
+++ b/rules/javascript/express-idor.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: ez-express-idor-param
+    message: >-
+      Direct use of req.params.id to find a database record without verifying
+      the current user owns it. This allows IDOR — attackers can access other
+      users' data by changing the ID in the URL.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      cwe: "CWE-639"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: $MODEL.findById(req.params.$ID)
+      - pattern: $MODEL.findByPk(req.params.$ID)
+      - pattern: "$MODEL.findOne({where: {id: req.params.$ID}})"
+      - pattern: "$MODEL.findOne({_id: req.params.$ID})"

--- a/rules/javascript/express-idor.yaml
+++ b/rules/javascript/express-idor.yaml
@@ -11,8 +11,14 @@ rules:
       owasp: "A01:2021 Broken Access Control"
       category: security
       confidence: MEDIUM
-    pattern-either:
-      - pattern: $MODEL.findById(req.params.$ID)
-      - pattern: $MODEL.findByPk(req.params.$ID)
-      - pattern: "$MODEL.findOne({where: {id: req.params.$ID}})"
-      - pattern: "$MODEL.findOne({_id: req.params.$ID})"
+    patterns:
+      - pattern-either:
+          - pattern: $MODEL.findById(req.params.$ID)
+          - pattern: $MODEL.findByPk(req.params.$ID)
+          - pattern: "$MODEL.findOne({where: {id: req.params.$ID}})"
+          - pattern: "$MODEL.findOne({_id: req.params.$ID})"
+      # Exclude lookups that also scope by the authenticated user (IDOR-safe).
+      # These match the common Mongoose/Sequelize "filter by userId" patterns.
+      - pattern-not: "$MODEL.findOne({ _id: req.params.$ID, userId: req.user.$FIELD })"
+      - pattern-not: "$MODEL.findOne({ _id: req.params.$ID, owner: req.user.$FIELD })"
+      - pattern-not: "$MODEL.findOne({ where: { id: req.params.$ID, userId: req.user.$FIELD } })"

--- a/rules/javascript/express-insecure-deserialization.yaml
+++ b/rules/javascript/express-insecure-deserialization.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: ez-express-insecure-deserialization
+    message: >-
+      Using node-serialize, js-yaml.load (without safeLoad), or eval-based
+      deserialization on user input allows arbitrary code execution. Use
+      JSON.parse or safe alternatives instead.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      cwe: "CWE-502"
+      owasp: "A08:2021 Software and Data Integrity Failures"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: serialize.unserialize(req.body.$DATA)
+      - pattern: serialize.unserialize(req.query.$DATA)
+      - pattern: $SERIALIZE.unserialize(req.body)
+      - pattern: yaml.load(req.body)
+      - pattern: |
+          $DATA = req.body
+          ...
+          serialize.unserialize($DATA)
+      - pattern: |
+          $DATA = req.body.$FIELD
+          ...
+          serialize.unserialize($DATA)

--- a/rules/javascript/express-mass-assignment.yaml
+++ b/rules/javascript/express-mass-assignment.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: ez-express-mass-assignment
+    message: >-
+      Spreading or directly passing req.body into a model create/update allows
+      mass assignment. An attacker can set sensitive fields like role or isAdmin
+      by adding unexpected fields to the request body.
+    severity: ERROR
+    languages: [javascript, typescript]
+    metadata:
+      cwe: "CWE-915"
+      owasp: "A04:2021 Insecure Design"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: $MODEL.create(req.body)
+      - pattern: $MODEL.create({...req.body})
+      - pattern: $MODEL.update(req.body, ...)
+      - pattern: $MODEL.findByIdAndUpdate($ID, req.body)
+      - pattern: $MODEL.findByIdAndUpdate($ID, {... req.body})
+      - pattern: new $MODEL(req.body)
+      - pattern: new $MODEL({...req.body})

--- a/rules/javascript/tests/test_csrf_missing_tn.js
+++ b/rules/javascript/tests/test_csrf_missing_tn.js
@@ -1,0 +1,8 @@
+// True negative: GET route (no CSRF needed, safe)
+const express = require('express');
+const app = express();
+
+// ok: ez-express-no-csrf
+app.get('/status', function(req, res) {
+    res.json({status: 'ok'});
+});

--- a/rules/javascript/tests/test_csrf_missing_tp.js
+++ b/rules/javascript/tests/test_csrf_missing_tp.js
@@ -1,0 +1,9 @@
+// True positive: POST route without CSRF middleware
+const express = require('express');
+const app = express();
+
+// ruleid: ez-express-no-csrf
+app.post('/transfer', function(req, res) {
+    doTransfer(req.body.amount);
+    res.json({ok: true});
+});

--- a/rules/javascript/tests/test_deserialization_tn.js
+++ b/rules/javascript/tests/test_deserialization_tn.js
@@ -1,0 +1,6 @@
+// True negative: JSON.parse is safe
+app.post('/import', (req, res) => {
+    // ok: ez-express-insecure-deserialization
+    const obj = JSON.parse(req.body.data);
+    res.json(obj);
+});

--- a/rules/javascript/tests/test_deserialization_tp.js
+++ b/rules/javascript/tests/test_deserialization_tp.js
@@ -1,0 +1,8 @@
+// True positive: node-serialize unserialize on user input
+const serialize = require('node-serialize');
+
+app.post('/import', (req, res) => {
+    // ruleid: ez-express-insecure-deserialization
+    const obj = serialize.unserialize(req.body.data);
+    res.json(obj);
+});

--- a/rules/javascript/tests/test_header_injection_tn.js
+++ b/rules/javascript/tests/test_header_injection_tn.js
@@ -1,0 +1,8 @@
+// True negative: hardcoded header value (safe)
+const express = require('express');
+
+app.get('/set-lang', (req, res) => {
+    // ok: ez-express-header-injection
+    res.setHeader('Content-Language', 'en-US');
+    res.send('OK');
+});

--- a/rules/javascript/tests/test_header_injection_tp.js
+++ b/rules/javascript/tests/test_header_injection_tp.js
@@ -1,0 +1,8 @@
+// True positive: user input in response header
+const express = require('express');
+
+app.get('/set-lang', (req, res) => {
+    // ruleid: ez-express-header-injection
+    res.setHeader('Content-Language', req.query.lang);
+    res.send('OK');
+});

--- a/rules/javascript/tests/test_idor_tn.js
+++ b/rules/javascript/tests/test_idor_tn.js
@@ -1,0 +1,11 @@
+// True negative: scoped to current user (safe)
+const express = require('express');
+
+app.get('/invoice/:id', async (req, res) => {
+    // ok: ez-express-idor-param
+    const invoice = await Invoice.findOne({
+        _id: req.params.id,
+        userId: req.user.id
+    });
+    res.json(invoice);
+});

--- a/rules/javascript/tests/test_idor_tp.js
+++ b/rules/javascript/tests/test_idor_tp.js
@@ -1,0 +1,8 @@
+// True positive: IDOR via direct findById without ownership check
+const express = require('express');
+
+app.get('/invoice/:id', async (req, res) => {
+    // ruleid: ez-express-idor-param
+    const invoice = await Invoice.findById(req.params.id);
+    res.json(invoice);
+});

--- a/rules/javascript/tests/test_mass_assignment_tn.js
+++ b/rules/javascript/tests/test_mass_assignment_tn.js
@@ -1,0 +1,11 @@
+// True negative: explicit field pick (safe)
+const express = require('express');
+
+app.post('/users', async (req, res) => {
+    // ok: ez-express-mass-assignment
+    const user = await User.create({
+        name: req.body.name,
+        email: req.body.email,
+    });
+    res.json(user);
+});

--- a/rules/javascript/tests/test_mass_assignment_tp.js
+++ b/rules/javascript/tests/test_mass_assignment_tp.js
@@ -1,0 +1,8 @@
+// True positive: mass assignment via req.body spread
+const express = require('express');
+
+app.post('/users', async (req, res) => {
+    // ruleid: ez-express-mass-assignment
+    const user = await User.create(req.body);
+    res.json(user);
+});

--- a/rules/php/laravel-csrf-exclude.yaml
+++ b/rules/php/laravel-csrf-exclude.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: ez-laravel-csrf-exclude
+    message: >-
+      Routes listed in VerifyCsrfToken::$except bypass CSRF verification.
+      This allows cross-site request forgery attacks against those endpoints.
+      For API routes, use Sanctum or Passport token auth instead.
+    severity: WARNING
+    languages: [php]
+    metadata:
+      cwe: "CWE-352"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: HIGH
+    pattern: |
+      class $CLASS extends VerifyCsrfToken {
+          protected $except = [...];
+      }

--- a/rules/php/laravel-header-injection.yaml
+++ b/rules/php/laravel-header-injection.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: ez-laravel-header-injection
+    message: >-
+      User input from the request is placed directly into a response header.
+      An attacker can inject CRLF characters to add arbitrary headers or split
+      the HTTP response, enabling cache poisoning or XSS.
+    severity: ERROR
+    languages: [php]
+    metadata:
+      cwe: "CWE-113"
+      owasp: "A03:2021 Injection"
+      category: security
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: "response()->header($NAME, $request->input(...))"
+      - pattern: "$RESP->header($NAME, $request->input(...))"
+      - pattern: "header($NAME . ': ' . $request->input(...))"

--- a/rules/php/laravel-idor.yaml
+++ b/rules/php/laravel-idor.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: ez-laravel-idor-find
+    message: >-
+      Direct use of request input to find a database record without scoping to
+      the authenticated user. This allows IDOR — attackers can access other
+      users' records by changing the ID parameter.
+    severity: ERROR
+    languages: [php]
+    metadata:
+      cwe: "CWE-639"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: $MODEL::find($request->input(...))
+      - pattern: $MODEL::find($request->$PARAM)
+      - pattern: $MODEL::findOrFail($request->input(...))
+      - pattern: $MODEL::where('id', $request->input(...))->first()

--- a/rules/php/laravel-idor.yaml
+++ b/rules/php/laravel-idor.yaml
@@ -11,8 +11,14 @@ rules:
       owasp: "A01:2021 Broken Access Control"
       category: security
       confidence: MEDIUM
-    pattern-either:
-      - pattern: $MODEL::find($request->input(...))
-      - pattern: $MODEL::find($request->$PARAM)
-      - pattern: $MODEL::findOrFail($request->input(...))
-      - pattern: $MODEL::where('id', $request->input(...))->first()
+    patterns:
+      - pattern-either:
+          - pattern: $MODEL::find($request->input(...))
+          - pattern: $MODEL::find($request->$PARAM)
+          - pattern: $MODEL::findOrFail($request->input(...))
+          - pattern: $MODEL::where('id', $request->input(...))->first()
+      # $MODEL must be a bare model class (e.g. Invoice), not a scoped receiver
+      # chain like auth()->user()->invoices() — those are IDOR-safe.
+      - metavariable-regex:
+          metavariable: $MODEL
+          regex: "^[A-Z][A-Za-z0-9_\\\\]*$"

--- a/rules/php/laravel-insecure-deserialization.yaml
+++ b/rules/php/laravel-insecure-deserialization.yaml
@@ -1,0 +1,25 @@
+rules:
+  - id: ez-laravel-insecure-deserialization
+    message: >-
+      Using unserialize() on user input allows arbitrary code execution via PHP
+      object injection. An attacker can craft a serialized payload that triggers
+      magic methods (__destruct, __wakeup) to execute arbitrary code. Use
+      json_decode() instead.
+    severity: ERROR
+    languages: [php]
+    metadata:
+      cwe: "CWE-502"
+      owasp: "A08:2021 Software and Data Integrity Failures"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: unserialize($request->input(...))
+      - pattern: unserialize($request->$PARAM)
+      - pattern: |
+          $DATA = $request->input(...);
+          ...
+          unserialize($DATA);
+      - pattern: |
+          $DATA = $request->$PARAM;
+          ...
+          unserialize($DATA);

--- a/rules/php/laravel-mass-assignment.yaml
+++ b/rules/php/laravel-mass-assignment.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: ez-laravel-mass-assignment
+    message: >-
+      Passing all request input directly to a model create/update without
+      validation allows mass assignment. An attacker can set sensitive fields
+      like is_admin by adding unexpected request parameters. Use
+      $request->validated() or $request->only([...]) instead.
+    severity: ERROR
+    languages: [php]
+    metadata:
+      cwe: "CWE-915"
+      owasp: "A04:2021 Insecure Design"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: $MODEL::create($request->all())
+      - pattern: $MODEL::update($request->all())
+      - pattern: $OBJ->fill($request->all())
+      - pattern: $OBJ->update($request->all())
+      - pattern: new $MODEL($request->all())

--- a/rules/php/tests/test_csrf_exclude_tn.php
+++ b/rules/php/tests/test_csrf_exclude_tn.php
@@ -1,0 +1,6 @@
+<?php
+// True negative: no CSRF exclusions (safe)
+// ok: ez-laravel-csrf-exclude
+class VerifyCsrfMiddleware extends VerifyCsrfToken {
+    // No exclusions — all routes are CSRF-protected
+}

--- a/rules/php/tests/test_csrf_exclude_tp.php
+++ b/rules/php/tests/test_csrf_exclude_tp.php
@@ -1,0 +1,9 @@
+<?php
+// True positive: CSRF exclusions
+// ruleid: ez-laravel-csrf-exclude
+class VerifyCsrfMiddleware extends VerifyCsrfToken {
+    protected $except = [
+        'api/*',
+        'webhook/*',
+    ];
+}

--- a/rules/php/tests/test_deserialization_tn.php
+++ b/rules/php/tests/test_deserialization_tn.php
@@ -1,0 +1,11 @@
+<?php
+// True negative: json_decode is safe
+class DataController extends Controller
+{
+    public function import(Request $request)
+    {
+        // ok: ez-laravel-insecure-deserialization
+        $obj = json_decode($request->input('data'), true);
+        return response()->json($obj);
+    }
+}

--- a/rules/php/tests/test_deserialization_tp.php
+++ b/rules/php/tests/test_deserialization_tp.php
@@ -1,0 +1,11 @@
+<?php
+// True positive: unserialize on user input
+class DataController extends Controller
+{
+    public function import(Request $request)
+    {
+        // ruleid: ez-laravel-insecure-deserialization
+        $obj = unserialize($request->input('data'));
+        return response()->json($obj);
+    }
+}

--- a/rules/php/tests/test_header_injection_tn.php
+++ b/rules/php/tests/test_header_injection_tn.php
@@ -1,0 +1,10 @@
+<?php
+// True negative: hardcoded header value (safe)
+class LanguageController extends Controller
+{
+    public function setLang()
+    {
+        // ok: ez-laravel-header-injection
+        return response('OK')->header('Content-Language', 'en-US');
+    }
+}

--- a/rules/php/tests/test_header_injection_tp.php
+++ b/rules/php/tests/test_header_injection_tp.php
@@ -1,0 +1,10 @@
+<?php
+// True positive: user input in response header
+class LanguageController extends Controller
+{
+    public function setLang(Request $request)
+    {
+        // ruleid: ez-laravel-header-injection
+        return response('OK')->header('Content-Language', $request->input('lang'));
+    }
+}

--- a/rules/php/tests/test_idor_tn.php
+++ b/rules/php/tests/test_idor_tn.php
@@ -1,0 +1,11 @@
+<?php
+// True negative: scoped to authenticated user (safe)
+class InvoiceController extends Controller
+{
+    public function show(Request $request)
+    {
+        // ok: ez-laravel-idor-find
+        $invoice = auth()->user()->invoices()->findOrFail($request->input('id'));
+        return response()->json($invoice);
+    }
+}

--- a/rules/php/tests/test_idor_tp.php
+++ b/rules/php/tests/test_idor_tp.php
@@ -1,0 +1,11 @@
+<?php
+// True positive: IDOR via direct find without scoping
+class InvoiceController extends Controller
+{
+    public function show(Request $request)
+    {
+        // ruleid: ez-laravel-idor-find
+        $invoice = Invoice::find($request->input('id'));
+        return response()->json($invoice);
+    }
+}

--- a/rules/php/tests/test_mass_assignment_tn.php
+++ b/rules/php/tests/test_mass_assignment_tn.php
@@ -1,0 +1,15 @@
+<?php
+// True negative: validated input (safe)
+class UserController extends Controller
+{
+    public function store(Request $request)
+    {
+        // ok: ez-laravel-mass-assignment
+        $validated = $request->validate([
+            'name' => 'required|string',
+            'email' => 'required|email',
+        ]);
+        $user = User::create($validated);
+        return response()->json($user);
+    }
+}

--- a/rules/php/tests/test_mass_assignment_tp.php
+++ b/rules/php/tests/test_mass_assignment_tp.php
@@ -1,0 +1,11 @@
+<?php
+// True positive: mass assignment via $request->all()
+class UserController extends Controller
+{
+    public function store(Request $request)
+    {
+        // ruleid: ez-laravel-mass-assignment
+        $user = User::create($request->all());
+        return response()->json($user);
+    }
+}

--- a/rules/python/django-csrf-exempt.yaml
+++ b/rules/python/django-csrf-exempt.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: ez-django-csrf-exempt
+    message: >-
+      View decorated with @csrf_exempt disables Django's CSRF protection.
+      This allows cross-site request forgery attacks against this endpoint.
+      If the endpoint modifies state, remove the exemption and use proper
+      CSRF tokens. For API endpoints, use token-based auth instead.
+    severity: WARNING
+    languages: [python]
+    metadata:
+      cwe: "CWE-352"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: HIGH
+    patterns:
+      - pattern: |
+          @csrf_exempt
+          def $FUNC(...):
+              ...
+      - pattern-not-inside: |
+          @require_http_methods(["GET"])
+          def $FUNC(...):
+              ...

--- a/rules/python/django-header-injection.yaml
+++ b/rules/python/django-header-injection.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: ez-django-header-injection
+    message: >-
+      User input is used directly in an HTTP response header without sanitization.
+      An attacker can inject CRLF characters to add arbitrary headers or split
+      the response, enabling cache poisoning or XSS via header injection.
+    severity: ERROR
+    languages: [python]
+    metadata:
+      cwe: "CWE-113"
+      owasp: "A03:2021 Injection"
+      category: security
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: |
+          $VAL = request.$METHOD.get(...)
+          ...
+          $RESPONSE[$HEADER] = $VAL
+      - pattern: |
+          $VAL = request.$METHOD.get(...)
+          ...
+          $RESPONSE.__setitem__($HEADER, $VAL)
+      - pattern: |
+          $VAL = request.$METHOD[...]
+          ...
+          $RESPONSE[$HEADER] = $VAL

--- a/rules/python/django-idor.yaml
+++ b/rules/python/django-idor.yaml
@@ -1,0 +1,23 @@
+rules:
+  - id: ez-django-idor-get-parameter
+    message: >-
+      Direct use of user-supplied ID from request to query database without
+      ownership check. This can lead to Insecure Direct Object Reference (IDOR)
+      where attackers access other users' data by changing the ID parameter.
+    severity: ERROR
+    languages: [python]
+    metadata:
+      cwe: "CWE-639"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: MEDIUM
+    patterns:
+      - pattern: |
+          $OBJ = request.$METHOD.get($KEY)
+          ...
+          $MODEL.objects.get($FIELD=$OBJ)
+      - pattern-not-inside: |
+          if $OBJ.owner == request.user:
+              ...
+      - pattern-not-inside: |
+          $MODEL.objects.filter(user=request.user).get(...)

--- a/rules/python/django-insecure-deserialization.yaml
+++ b/rules/python/django-insecure-deserialization.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: ez-django-insecure-deserialization
+    message: >-
+      Deserializing untrusted data with pickle or yaml.load (without SafeLoader)
+      allows arbitrary code execution. An attacker can craft a malicious payload
+      that runs arbitrary Python code on the server.
+    severity: ERROR
+    languages: [python]
+    metadata:
+      cwe: "CWE-502"
+      owasp: "A08:2021 Software and Data Integrity Failures"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: pickle.loads(request.$METHOD.get(...))
+      - pattern: pickle.loads(request.body)
+      - pattern: |
+          $DATA = request.$METHOD.get(...)
+          ...
+          pickle.loads($DATA)
+      - pattern: |
+          $DATA = request.body
+          ...
+          pickle.loads($DATA)
+      - pattern: yaml.load(request.body, ...)
+      - pattern: yaml.load(request.$METHOD.get(...), ...)
+      - patterns:
+          - pattern: yaml.load($DATA, ...)
+          - pattern-not: yaml.load($DATA, Loader=yaml.SafeLoader)
+          - pattern-not: yaml.load($DATA, Loader=yaml.CSafeLoader)
+          - pattern-inside: |
+              $DATA = request.$METHOD.get(...)
+              ...

--- a/rules/python/django-mass-assignment.yaml
+++ b/rules/python/django-mass-assignment.yaml
@@ -1,0 +1,25 @@
+rules:
+  - id: ez-django-mass-assignment
+    message: >-
+      Using **kwargs or request.POST.dict() to update model fields allows
+      mass assignment. An attacker can set fields like is_admin or is_staff
+      by adding unexpected POST parameters.
+    severity: ERROR
+    languages: [python]
+    metadata:
+      cwe: "CWE-915"
+      owasp: "A04:2021 Insecure Design"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: $MODEL.objects.create(**request.POST.dict())
+      - pattern: $MODEL.objects.update(**request.POST.dict())
+      - pattern: $MODEL(**request.POST.dict())
+      - pattern: |
+          $DATA = request.POST.dict()
+          ...
+          $MODEL.objects.create(**$DATA)
+      - pattern: |
+          $DATA = request.POST.dict()
+          ...
+          $MODEL(**$DATA)

--- a/rules/python/tests/test_csrf_exempt_tn.py
+++ b/rules/python/tests/test_csrf_exempt_tn.py
@@ -1,0 +1,7 @@
+# True negative: no csrf_exempt decorator (safe)
+from django.http import JsonResponse
+
+def transfer_funds(request):
+    # ok: ez-django-csrf-exempt
+    amount = request.POST.get("amount")
+    return do_transfer(amount)

--- a/rules/python/tests/test_csrf_exempt_tp.py
+++ b/rules/python/tests/test_csrf_exempt_tp.py
@@ -1,0 +1,8 @@
+# True positive: csrf_exempt on a state-changing view
+from django.views.decorators.csrf import csrf_exempt
+
+# ruleid: ez-django-csrf-exempt
+@csrf_exempt
+def transfer_funds(request):
+    amount = request.POST.get("amount")
+    return do_transfer(amount)

--- a/rules/python/tests/test_deserialization_tn.py
+++ b/rules/python/tests/test_deserialization_tn.py
@@ -1,0 +1,8 @@
+# True negative: json.loads is safe
+import json
+
+def load_data(request):
+    # ok: ez-django-insecure-deserialization
+    data = request.body
+    obj = json.loads(data)
+    return obj

--- a/rules/python/tests/test_deserialization_tp.py
+++ b/rules/python/tests/test_deserialization_tp.py
@@ -1,0 +1,8 @@
+# True positive: pickle deserialization of user input
+import pickle
+
+def load_data(request):
+    # ruleid: ez-django-insecure-deserialization
+    data = request.body
+    obj = pickle.loads(data)
+    return obj

--- a/rules/python/tests/test_header_injection_tn.py
+++ b/rules/python/tests/test_header_injection_tn.py
@@ -1,0 +1,8 @@
+# True negative: hardcoded header value (safe)
+from django.http import HttpResponse
+
+def set_language(request):
+    # ok: ez-django-header-injection
+    response = HttpResponse("OK")
+    response["Content-Language"] = "en-US"
+    return response

--- a/rules/python/tests/test_header_injection_tp.py
+++ b/rules/python/tests/test_header_injection_tp.py
@@ -1,0 +1,9 @@
+# True positive: user input placed into response header
+from django.http import HttpResponse
+
+def set_language(request):
+    # ruleid: ez-django-header-injection
+    lang = request.GET.get("lang")
+    response = HttpResponse("OK")
+    response["Content-Language"] = lang
+    return response

--- a/rules/python/tests/test_idor_tn.py
+++ b/rules/python/tests/test_idor_tn.py
@@ -1,0 +1,8 @@
+# True negative: lookup scoped to current user (safe)
+from django.http import JsonResponse
+
+def get_invoice(request):
+    # ok: ez-django-idor-get-parameter
+    invoice_id = request.GET.get("id")
+    invoice = Invoice.objects.filter(user=request.user).get(pk=invoice_id)
+    return JsonResponse({"total": invoice.total})

--- a/rules/python/tests/test_idor_tp.py
+++ b/rules/python/tests/test_idor_tp.py
@@ -1,0 +1,8 @@
+# True positive: IDOR via direct object lookup without ownership check
+from django.http import JsonResponse
+
+def get_invoice(request):
+    # ruleid: ez-django-idor-get-parameter
+    invoice_id = request.GET.get("id")
+    invoice = Invoice.objects.get(pk=invoice_id)
+    return JsonResponse({"total": invoice.total})

--- a/rules/python/tests/test_mass_assignment_tn.py
+++ b/rules/python/tests/test_mass_assignment_tn.py
@@ -1,0 +1,10 @@
+# True negative: explicit field assignment (safe)
+from django.http import JsonResponse
+
+def create_user(request):
+    # ok: ez-django-mass-assignment
+    User.objects.create(
+        username=request.POST.get("username"),
+        email=request.POST.get("email"),
+    )
+    return JsonResponse({"ok": True})

--- a/rules/python/tests/test_mass_assignment_tp.py
+++ b/rules/python/tests/test_mass_assignment_tp.py
@@ -1,0 +1,7 @@
+# True positive: mass assignment via request.POST.dict()
+from django.http import JsonResponse
+
+def create_user(request):
+    # ruleid: ez-django-mass-assignment
+    User.objects.create(**request.POST.dict())
+    return JsonResponse({"ok": True})

--- a/rules/ruby/rails-csrf-skip.yaml
+++ b/rules/ruby/rails-csrf-skip.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: ez-rails-csrf-skip
+    message: >-
+      Skipping CSRF verification disables Rails' built-in CSRF protection for
+      the controller. This allows cross-site request forgery attacks. For API
+      controllers, use token-based auth instead of disabling CSRF globally.
+    severity: WARNING
+    languages: [ruby]
+    metadata:
+      cwe: "CWE-352"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: "skip_before_action :verify_authenticity_token"
+      - pattern: skip_forgery_protection
+      - pattern: "protect_from_forgery with: :null_session"

--- a/rules/ruby/rails-header-injection.yaml
+++ b/rules/ruby/rails-header-injection.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: ez-rails-header-injection
+    message: >-
+      User-supplied parameter is used directly in a response header. An attacker
+      can inject CRLF characters to add arbitrary headers or split the HTTP
+      response, enabling cache poisoning or XSS.
+    severity: ERROR
+    languages: [ruby]
+    metadata:
+      cwe: "CWE-113"
+      owasp: "A03:2021 Injection"
+      category: security
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: response.headers[$KEY] = params[...]
+      - pattern: response.set_header($KEY, params[...])
+      - pattern: headers[$KEY] = params[...]

--- a/rules/ruby/rails-idor.yaml
+++ b/rules/ruby/rails-idor.yaml
@@ -11,7 +11,13 @@ rules:
       owasp: "A01:2021 Broken Access Control"
       category: security
       confidence: MEDIUM
-    pattern-either:
-      - pattern: $MODEL.find(params[...])
-      - pattern: "$MODEL.find_by(id: params[...])"
-      - pattern: $MODEL.find_by_id(params[...])
+    patterns:
+      - pattern-either:
+          - pattern: $MODEL.find(params[...])
+          - pattern: "$MODEL.find_by(id: params[...])"
+          - pattern: $MODEL.find_by_id(params[...])
+      # $MODEL must be a bare model class (e.g. Invoice), not a scoped receiver
+      # like current_user.invoices or @user.invoices — those are IDOR-safe.
+      - metavariable-regex:
+          metavariable: $MODEL
+          regex: "^[A-Z][A-Za-z0-9_]*$"

--- a/rules/ruby/rails-idor.yaml
+++ b/rules/ruby/rails-idor.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: ez-rails-idor-find
+    message: >-
+      Direct use of params[:id] to find a record without scoping to the current
+      user. This allows IDOR — attackers can access other users' records by
+      changing the ID in the request.
+    severity: ERROR
+    languages: [ruby]
+    metadata:
+      cwe: "CWE-639"
+      owasp: "A01:2021 Broken Access Control"
+      category: security
+      confidence: MEDIUM
+    pattern-either:
+      - pattern: $MODEL.find(params[...])
+      - pattern: "$MODEL.find_by(id: params[...])"
+      - pattern: $MODEL.find_by_id(params[...])

--- a/rules/ruby/rails-insecure-deserialization.yaml
+++ b/rules/ruby/rails-insecure-deserialization.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: ez-rails-insecure-deserialization
+    message: >-
+      Deserializing untrusted data with Marshal.load or YAML.load (without
+      safe_load) allows arbitrary code execution. An attacker can craft a payload
+      that runs arbitrary Ruby code on the server.
+    severity: ERROR
+    languages: [ruby]
+    metadata:
+      cwe: "CWE-502"
+      owasp: "A08:2021 Software and Data Integrity Failures"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: Marshal.load(params[...])
+      - pattern: Marshal.load(request.body.read)
+      - pattern: YAML.load(params[...])
+      - pattern: YAML.load(request.body.read)
+      - pattern: |
+          $DATA = params[...]
+          ...
+          Marshal.load($DATA)
+      - pattern: |
+          $DATA = params[...]
+          ...
+          YAML.load($DATA)

--- a/rules/ruby/rails-mass-assignment.yaml
+++ b/rules/ruby/rails-mass-assignment.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: ez-rails-mass-assignment-permit-all
+    message: >-
+      Using permit! or params.to_unsafe_h allows all request parameters to be
+      mass-assigned. An attacker can set sensitive fields like admin or role by
+      adding unexpected parameters. Use strong parameters with an explicit
+      allow-list instead.
+    severity: ERROR
+    languages: [ruby]
+    metadata:
+      cwe: "CWE-915"
+      owasp: "A04:2021 Insecure Design"
+      category: security
+      confidence: HIGH
+    pattern-either:
+      - pattern: params.permit!
+      - pattern: params.to_unsafe_h
+      - pattern: params.to_unsafe_hash
+      - pattern: params.require(...).permit!

--- a/rules/ruby/tests/test_csrf_skip_tn.rb
+++ b/rules/ruby/tests/test_csrf_skip_tn.rb
@@ -1,0 +1,5 @@
+# True negative: CSRF protection enabled (safe)
+class ApplicationController < ActionController::Base
+  # ok: ez-rails-csrf-skip
+  protect_from_forgery with: :exception
+end

--- a/rules/ruby/tests/test_csrf_skip_tp.rb
+++ b/rules/ruby/tests/test_csrf_skip_tp.rb
@@ -1,0 +1,5 @@
+# True positive: CSRF protection disabled
+class ApiController < ApplicationController
+  # ruleid: ez-rails-csrf-skip
+  skip_before_action :verify_authenticity_token
+end

--- a/rules/ruby/tests/test_deserialization_tn.rb
+++ b/rules/ruby/tests/test_deserialization_tn.rb
@@ -1,0 +1,8 @@
+# True negative: JSON.parse is safe
+class DataController < ApplicationController
+  def import
+    # ok: ez-rails-insecure-deserialization
+    obj = JSON.parse(params[:data])
+    render json: obj
+  end
+end

--- a/rules/ruby/tests/test_deserialization_tp.rb
+++ b/rules/ruby/tests/test_deserialization_tp.rb
@@ -1,0 +1,8 @@
+# True positive: Marshal.load with user input
+class DataController < ApplicationController
+  def import
+    # ruleid: ez-rails-insecure-deserialization
+    obj = Marshal.load(params[:data])
+    render json: obj
+  end
+end

--- a/rules/ruby/tests/test_header_injection_tn.rb
+++ b/rules/ruby/tests/test_header_injection_tn.rb
@@ -1,0 +1,7 @@
+# True negative: hardcoded header value (safe)
+class LanguageController < ApplicationController
+  def set_lang
+    # ok: ez-rails-header-injection
+    response.headers["Content-Language"] = "en-US"
+  end
+end

--- a/rules/ruby/tests/test_header_injection_tp.rb
+++ b/rules/ruby/tests/test_header_injection_tp.rb
@@ -1,0 +1,7 @@
+# True positive: user input in response header
+class LanguageController < ApplicationController
+  def set_lang
+    # ruleid: ez-rails-header-injection
+    response.headers["Content-Language"] = params[:lang]
+  end
+end

--- a/rules/ruby/tests/test_idor_tn.rb
+++ b/rules/ruby/tests/test_idor_tn.rb
@@ -1,0 +1,8 @@
+# True negative: scoped to current_user (safe)
+class InvoicesController < ApplicationController
+  def show
+    # ok: ez-rails-idor-find
+    @invoice = current_user.invoices.find(params[:id])
+    render json: @invoice
+  end
+end

--- a/rules/ruby/tests/test_idor_tp.rb
+++ b/rules/ruby/tests/test_idor_tp.rb
@@ -1,0 +1,8 @@
+# True positive: IDOR via direct find without scoping
+class InvoicesController < ApplicationController
+  def show
+    # ruleid: ez-rails-idor-find
+    @invoice = Invoice.find(params[:id])
+    render json: @invoice
+  end
+end

--- a/rules/ruby/tests/test_mass_assignment_tn.rb
+++ b/rules/ruby/tests/test_mass_assignment_tn.rb
@@ -1,0 +1,7 @@
+# True negative: explicit permit list (safe)
+class UsersController < ApplicationController
+  def create
+    # ok: ez-rails-mass-assignment-permit-all
+    User.create(params.require(:user).permit(:name, :email))
+  end
+end

--- a/rules/ruby/tests/test_mass_assignment_tp.rb
+++ b/rules/ruby/tests/test_mass_assignment_tp.rb
@@ -1,0 +1,7 @@
+# True positive: mass assignment via permit!
+class UsersController < ApplicationController
+  def create
+    # ruleid: ez-rails-mass-assignment-permit-all
+    User.create(params.permit!)
+  end
+end

--- a/scripts/verify-rule-fixtures.py
+++ b/scripts/verify-rule-fixtures.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Verify custom semgrep rule packs against their TP/TN fixtures.
+
+This script is intentionally dependency-light enough to run inside ez-appsec
+Docker images after they are built. It verifies every rule file under rules/*:
+  - rule YAML is parseable by semgrep
+  - its true-positive fixture produces at least one finding
+  - its true-negative fixture produces zero findings
+
+Fixture mapping is discovered from inline comments:
+  # ruleid: <rule-id>
+  # ok: <rule-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+RULES_ROOT = Path("rules")
+LANGUAGES = ["python", "ruby", "java", "javascript", "php"]
+RULEREF_RE = re.compile(r"ruleid:\s*([\w.-]+)|ok:\s*([\w.-]+)")
+
+
+def run_semgrep(rule_yaml: Path, target: Path) -> tuple[int, list[str]]:
+    proc = subprocess.run(
+        ["semgrep", "--config", str(rule_yaml), str(target), "--json", "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return -1, [f"semgrep produced non-JSON output (rc={proc.returncode}): {proc.stderr[:200]}"]
+    findings = len(data.get("results", []))
+    errors = [
+        str(e.get("message", e))[:200]
+        for e in data.get("errors", [])
+        if e.get("code") != "TargetParseError"
+    ]
+    return findings, errors
+
+
+def load_rule_id(rule_yaml: Path) -> str:
+    data = yaml.safe_load(rule_yaml.read_text())
+    rules = data.get("rules", [])
+    if not rules or not rules[0].get("id"):
+        raise ValueError(f"{rule_yaml}: missing rules[0].id")
+    return str(rules[0]["id"])
+
+
+def fixtures_for_rule(rule_yaml: Path, language: str) -> tuple[Path | None, Path | None]:
+    rule_id = load_rule_id(rule_yaml)
+    tests_dir = RULES_ROOT / language / "tests"
+    tp = tn = None
+    for fixture in tests_dir.iterdir():
+        if not fixture.is_file():
+            continue
+        refs = {m.group(1) or m.group(2) for m in RULEREF_RE.finditer(fixture.read_text())}
+        if rule_id not in refs:
+            continue
+        if "_tp" in fixture.name.lower():
+            tp = fixture
+        elif "_tn" in fixture.name.lower():
+            tn = fixture
+    return tp, tn
+
+
+def all_rules() -> list[tuple[str, Path]]:
+    cases: list[tuple[str, Path]] = []
+    for language in LANGUAGES:
+        lang_dir = RULES_ROOT / language
+        if not lang_dir.is_dir():
+            continue
+        for rule_yaml in sorted(lang_dir.glob("*.yaml")):
+            cases.append((language, rule_yaml))
+    return cases
+
+
+def validate_rule(rule_yaml: Path) -> list[str]:
+    empty_target = Path(tempfile.gettempdir()) / "ez_appsec_empty_target"
+    empty_target.mkdir(exist_ok=True)
+    _, errors = run_semgrep(rule_yaml, empty_target)
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--allow-missing-semgrep",
+        action="store_true",
+        help="Exit 0 when semgrep is missing (for images intentionally built without semgrep).",
+    )
+    args = parser.parse_args()
+
+    if shutil.which("semgrep") is None:
+        msg = "semgrep is not installed; cannot verify rule fixtures"
+        if args.allow_missing_semgrep:
+            print(f"SKIP: {msg}")
+            return 0
+        print(f"ERROR: {msg}", file=sys.stderr)
+        return 2
+
+    failures: list[str] = []
+    passed = 0
+    for language, rule_yaml in all_rules():
+        rule_id = load_rule_id(rule_yaml)
+        errors = validate_rule(rule_yaml)
+        if errors:
+            failures.append(f"{rule_yaml}: invalid rule config: {errors[:2]}")
+            continue
+
+        tp, tn = fixtures_for_rule(rule_yaml, language)
+        if tp is None:
+            failures.append(f"{rule_yaml}: no true-positive fixture references {rule_id}")
+            continue
+        if tn is None:
+            failures.append(f"{rule_yaml}: no true-negative fixture references {rule_id}")
+            continue
+
+        tp_count, tp_errors = run_semgrep(rule_yaml, tp)
+        tn_count, tn_errors = run_semgrep(rule_yaml, tn)
+        if tp_errors:
+            failures.append(f"{rule_yaml} -> {tp}: semgrep errors: {tp_errors[:2]}")
+            continue
+        if tn_errors:
+            failures.append(f"{rule_yaml} -> {tn}: semgrep errors: {tn_errors[:2]}")
+            continue
+        if tp_count < 1:
+            failures.append(f"{rule_yaml} -> {tp}: TRUE POSITIVE produced 0 findings")
+            continue
+        if tn_count != 0:
+            failures.append(f"{rule_yaml} -> {tn}: TRUE NEGATIVE produced {tn_count} findings")
+            continue
+        passed += 1
+        print(f"OK {language}/{rule_yaml.name}: tp={tp_count} tn={tn_count}")
+
+    if failures:
+        print("\nRule fixture verification failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print(f"\nRule fixture verification passed: {passed} rules")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -1,0 +1,159 @@
+"""Tests for PLAN-16 custom semgrep rule packs.
+
+Validates:
+- Rule YAML schema (required fields: id, message, severity, languages, pattern/pattern-either/patterns)
+- resolve_rules_dirs maps language names to directories
+- Rule file counts per language pack (>= 5)
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ez_appsec.external_scanners import resolve_rules_dirs, RULES_LANGUAGE_MAP
+
+RULES_ROOT = Path(__file__).parent.parent / "rules"
+LANGUAGES = ["python", "ruby", "java", "javascript", "php"]
+
+REQUIRED_RULE_FIELDS = {"id", "message", "severity", "languages"}
+PATTERN_FIELDS = {"pattern", "pattern-either", "patterns", "pattern-regex"}
+
+
+def _load_rules(language: str):
+    """Load all rules from a language pack, yielding (file, rule) pairs."""
+    lang_dir = RULES_ROOT / language
+    for yaml_file in sorted(lang_dir.glob("*.yaml")):
+        with open(yaml_file) as f:
+            data = yaml.safe_load(f)
+        for rule in data.get("rules", []):
+            yield yaml_file.name, rule
+
+
+class TestRuleYAMLSchema:
+    """Each rule must have the required semgrep fields."""
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_language_pack_exists(self, language):
+        lang_dir = RULES_ROOT / language
+        assert lang_dir.is_dir(), f"Missing rules/{language}/ directory"
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_minimum_rule_count(self, language):
+        rules = list(_load_rules(language))
+        assert len(rules) >= 5, (
+            f"{language} has only {len(rules)} rule(s), need >= 5"
+        )
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_required_fields(self, language):
+        for filename, rule in _load_rules(language):
+            for field in REQUIRED_RULE_FIELDS:
+                assert field in rule, (
+                    f"{language}/{filename} rule '{rule.get('id', '?')}' missing '{field}'"
+                )
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_has_pattern(self, language):
+        for filename, rule in _load_rules(language):
+            has_pattern = any(f in rule for f in PATTERN_FIELDS)
+            assert has_pattern, (
+                f"{language}/{filename} rule '{rule.get('id', '?')}' has no pattern field"
+            )
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_severity_values(self, language):
+        valid = {"ERROR", "WARNING", "INFO"}
+        for filename, rule in _load_rules(language):
+            assert rule["severity"] in valid, (
+                f"{language}/{filename} rule '{rule['id']}' has invalid severity "
+                f"'{rule['severity']}', expected one of {valid}"
+            )
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_metadata_has_cwe(self, language):
+        for filename, rule in _load_rules(language):
+            meta = rule.get("metadata", {})
+            assert "cwe" in meta, (
+                f"{language}/{filename} rule '{rule['id']}' missing metadata.cwe"
+            )
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_metadata_has_category_security(self, language):
+        for filename, rule in _load_rules(language):
+            meta = rule.get("metadata", {})
+            assert meta.get("category") == "security", (
+                f"{language}/{filename} rule '{rule['id']}' metadata.category "
+                f"should be 'security', got '{meta.get('category')}'"
+            )
+
+
+class TestTestFixtures:
+    """Each rule should have test fixtures."""
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_fixtures_directory_exists(self, language):
+        tests_dir = RULES_ROOT / language / "tests"
+        assert tests_dir.is_dir(), f"Missing rules/{language}/tests/ directory"
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_has_true_positive_fixtures(self, language):
+        tests_dir = RULES_ROOT / language / "tests"
+        tp_files = list(tests_dir.glob("*_tp.*"))
+        assert len(tp_files) >= 5, (
+            f"{language} has only {len(tp_files)} true-positive fixture(s), need >= 5"
+        )
+
+    @pytest.mark.parametrize("language", LANGUAGES)
+    def test_has_true_negative_fixtures(self, language):
+        tests_dir = RULES_ROOT / language / "tests"
+        tn_files = list(tests_dir.glob("*_tn.*"))
+        assert len(tn_files) >= 5, (
+            f"{language} has only {len(tn_files)} true-negative fixture(s), need >= 5"
+        )
+
+
+class TestResolveRulesDirs:
+    """Test the resolve_rules_dirs helper."""
+
+    def test_resolve_python(self):
+        dirs = resolve_rules_dirs(["python"])
+        assert len(dirs) == 1
+        assert dirs[0].endswith("/python")
+
+    def test_resolve_all(self):
+        dirs = resolve_rules_dirs(["all"])
+        assert len(dirs) >= 5
+
+    def test_resolve_framework_alias(self):
+        dirs = resolve_rules_dirs(["django"])
+        assert len(dirs) == 1
+        assert dirs[0].endswith("/python")
+
+    def test_resolve_multiple(self):
+        dirs = resolve_rules_dirs(["ruby", "php"])
+        assert len(dirs) == 2
+
+    def test_resolve_unknown_warns(self, caplog):
+        dirs = resolve_rules_dirs(["cobol"])
+        assert len(dirs) == 0
+
+    def test_language_map_completeness(self):
+        for lang in LANGUAGES:
+            assert lang in RULES_LANGUAGE_MAP
+
+
+class TestSemgrepScannerExtraRules:
+    """Test that SemgrepScanner accepts extra_rules_dirs."""
+
+    def test_init_default_empty(self):
+        from ez_appsec.external_scanners import SemgrepScanner
+        scanner = SemgrepScanner()
+        assert scanner.extra_rules_dirs == []
+
+    def test_init_with_dirs(self):
+        from ez_appsec.external_scanners import SemgrepScanner
+        dirs = ["/tmp/rules/python"]
+        scanner = SemgrepScanner(extra_rules_dirs=dirs)
+        assert scanner.extra_rules_dirs == dirs

--- a/tests/test_external_scanners.py
+++ b/tests/test_external_scanners.py
@@ -1,5 +1,7 @@
 """Tests for external scanner wrappers"""
 
+from unittest.mock import patch
+
 import pytest
 from ez_appsec.external_scanners import (
     GitleaksScanner,
@@ -262,6 +264,18 @@ class TestSemgrepAIRemediation:
         result = scanner._add_ai_remediation_fields(finding, source)
         assert result["fix_type"] == "code_change"
         assert result["fix_complexity"] == "moderate"
+
+
+class TestGrypeDependencyInstall:
+    def test_missing_package_manager_does_not_crash(self, tmp_path, caplog):
+        """Thin images omit npm/pip; dependency manifest generation should degrade to a warning."""
+        (tmp_path / "package.json").write_text('{"name":"demo","dependencies":{"left-pad":"1.3.0"}}')
+        scanner = GrypeScanner()
+
+        with patch("ez_appsec.external_scanners.subprocess.run", side_effect=FileNotFoundError("npm")):
+            scanner._install_dependencies(str(tmp_path))
+
+        assert "Dependency manifest generation skipped: npm is not installed" in caplog.text
 
 
 class TestKicsAIRemediation:

--- a/tests/test_rule_fixtures.py
+++ b/tests/test_rule_fixtures.py
@@ -1,0 +1,204 @@
+"""Functional tests for custom SAST rule packs (PLAN-16).
+
+These tests run semgrep against every rule's own TP/TN fixture pair and assert:
+  - the true-positive fixture produces >= 1 finding (catches FALSE_NEGATIVE rules)
+  - the true-negative fixture produces 0 findings (catches FALSE_POSITIVE rules)
+  - the rule YAML validates without parse errors
+
+This is the verification the schema tests in test_custom_rules.py do NOT provide:
+they check structure but never prove a rule actually matches vulnerable code or
+correctly excludes safe code. These tests would have caught all 4 of the broken
+IDOR rules shipped in the initial PLAN-16 PR.
+
+Fixtures are auto-discovered: a fixture file belongs to a rule if it contains a
+``# ruleid: <rule_id>`` or ``# ok: <rule_id>`` comment referencing that rule.
+This avoids maintaining a brittle filename<->rule mapping.
+
+Skipped automatically when semgrep is not installed (honors the project
+convention of keeping CI light and not bundling semgrep as a hard dependency).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+RULES_ROOT = Path(__file__).parent.parent / "rules"
+LANGUAGES = ["python", "ruby", "java", "javascript", "php"]
+
+# Shared empty target dir used by the validate test. Semgrep's `--validate` flag
+# does not reliably emit JSON in all versions; instead we scan an empty dir and
+# inspect the errors array for rule parse failures.
+_EMPTY_TARGET = Path(tempfile.gettempdir()) / "ez_appsec_empty_target"
+_EMPTY_TARGET.mkdir(exist_ok=True)
+
+# Match `# ruleid: <id>` or `# ok: <id>` (leading comment char varies by language).
+RULEREF_RE = re.compile(r"ruleid:\s*([\w.-]+)|ok:\s*([\w.-]+)")
+
+
+def _semgrep_available() -> bool:
+    """True if a usable semgrep binary is on PATH."""
+    return shutil.which("semgrep") is not None
+
+
+# Skip the entire module when semgrep is not installed. This keeps the test
+# suite green in minimal CI environments while still running in any environment
+# that has semgrep (developer machines, the rule-quality CI job, etc.).
+pytestmark = pytest.mark.skipif(
+    not _semgrep_available(),
+    reason="semgrep not installed on PATH — install with `pip install semgrep` to run rule fixture tests",
+)
+
+
+def _run_semgrep(rule_yaml: Path, target: Path) -> tuple[int, list[str]]:
+    """Run semgrep with one rule against one file. Returns (finding_count, error_messages).
+
+    Only *rule* parse errors are surfaced as failures; file-target parse errors
+    (e.g. a fixture that uses framework imports semgrep cannot resolve) are
+    filtered out since fixtures are intentionally minimal snippets.
+    """
+    proc = subprocess.run(
+        ["semgrep", "--config", str(rule_yaml), str(target), "--json", "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return -1, [f"semgrep produced non-JSON output (rc={proc.returncode}): {proc.stderr[:200]}"]
+    findings = len(data.get("results", []))
+    all_errors = data.get("errors", [])
+    # Distinguish rule-level parse errors (always fail) from target-level parse
+    # errors (expected for minimal fixtures — filter out).
+    rule_errors = [
+        e.get("message", str(e))[:200]
+        for e in all_errors
+        if e.get("code") != "TargetParseError"
+        and "Parse error" not in str(e.get("message", ""))
+    ]
+    return findings, rule_errors
+
+
+def _load_rule_id(rule_yaml: Path) -> str | None:
+    """Extract the first rule id from a rule YAML file."""
+    data = yaml.safe_load(rule_yaml.read_text())
+    rules = data.get("rules", [])
+    return rules[0].get("id") if rules else None
+
+
+def _fixtures_for_rule(rule_yaml: Path, language: str) -> tuple[Path | None, Path | None]:
+    """Find the TP and TN fixtures whose `# ruleid:`/`# ok:` comments reference this rule.
+
+    Returns (tp_path, tn_path) - either may be None if no fixture references the rule.
+    """
+    rule_id = _load_rule_id(rule_yaml)
+    if not rule_id:
+        return None, None
+    tests_dir = RULES_ROOT / language / "tests"
+    if not tests_dir.is_dir():
+        return None, None
+    tp = tn = None
+    for fixture in tests_dir.iterdir():
+        if not fixture.is_file():
+            continue
+        text = fixture.read_text()
+        refs = {m.group(1) or m.group(2) for m in RULEREF_RE.finditer(text)}
+        if rule_id not in refs:
+            continue
+        name = fixture.name.lower()
+        if "_tp" in name:
+            tp = fixture
+        elif "_tn" in name:
+            tn = fixture
+    return tp, tn
+
+
+def _all_rules():
+    """Return (language, rule_yaml_path) for every rule file across all language packs."""
+    cases = []
+    for language in LANGUAGES:
+        lang_dir = RULES_ROOT / language
+        if not lang_dir.is_dir():
+            continue
+        for rule_yaml in sorted(lang_dir.glob("*.yaml")):
+            cases.append((language, rule_yaml))
+    return cases
+
+
+@pytest.mark.parametrize("language, rule_yaml", _all_rules())
+def test_rule_yaml_validates(language, rule_yaml):
+    """Rule YAML must be syntactically valid semgrep config (catches PatternParseError).
+
+    Uses an empty-target scan rather than `semgrep --validate --json` because the
+    latter does not reliably emit parseable JSON across semgrep versions. Any
+    rule-level parse error (malformed pattern, invalid metavariable usage) shows
+    up in the scan's errors array regardless of the target scanned.
+    """
+    proc = subprocess.run(
+        ["semgrep", "--config", str(rule_yaml), str(_EMPTY_TARGET), "--json", "--quiet"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        pytest.fail(
+            f"{rule_yaml.name}: semgrep scan produced non-JSON output (rc={proc.returncode}): "
+            f"{proc.stderr[:300]}"
+        )
+    rule_errors = [
+        e for e in data.get("errors", [])
+        if e.get("code") != "TargetParseError"
+    ]
+    if rule_errors:
+        msgs = "; ".join(str(e.get("message", e))[:200] for e in rule_errors)
+        pytest.fail(f"{rule_yaml.name}: invalid semgrep rule - {msgs}")
+
+
+@pytest.mark.parametrize("language, rule_yaml", _all_rules())
+def test_rule_true_positive_fires(language, rule_yaml):
+    """The rule's true-positive fixture must produce at least one finding.
+
+    A zero here means the rule does not match the vulnerable code it claims to
+    catch (FALSE_NEGATIVE) - usually a malformed pattern or an over-broad
+    pattern-not exclusion.
+    """
+    tp, _ = _fixtures_for_rule(rule_yaml, language)
+    if tp is None:
+        pytest.skip(f"no true-positive fixture references {rule_yaml.name}")
+    count, errors = _run_semgrep(rule_yaml, tp)
+    if errors:
+        pytest.fail(f"{rule_yaml.name} -> {tp.name}: semgrep errors: {errors[:2]}")
+    assert count >= 1, (
+        f"{rule_yaml.name} -> {tp.name}: TRUE POSITIVE produced 0 findings "
+        f"(rule does not match its own vulnerable fixture - FALSE NEGATIVE)"
+    )
+
+
+@pytest.mark.parametrize("language, rule_yaml", _all_rules())
+def test_rule_true_negative_clean(language, rule_yaml):
+    """The rule's true-negative fixture must produce zero findings.
+
+    A non-zero here means the rule flags safe code (FALSE POSITIVE) - usually a
+    missing pattern-not exclusion for the scoped/safe variant.
+    """
+    _, tn = _fixtures_for_rule(rule_yaml, language)
+    if tn is None:
+        pytest.skip(f"no true-negative fixture references {rule_yaml.name}")
+    count, errors = _run_semgrep(rule_yaml, tn)
+    if errors:
+        pytest.fail(f"{rule_yaml.name} -> {tn.name}: semgrep errors: {errors[:2]}")
+    assert count == 0, (
+        f"{rule_yaml.name} -> {tn.name}: TRUE NEGATIVE produced {count} finding(s) "
+        f"(rule flags safe code - FALSE POSITIVE; add a pattern-not exclusion for the scoped variant)"
+    )


### PR DESCRIPTION
## Summary

- Custom semgrep rule packs for **Python/Django**, **Ruby/Rails**, **Java/Spring**, **Node/Express**, and **PHP/Laravel**
- Each pack covers 5 vulnerability classes: IDOR, mass assignment, CSRF bypass, header injection, insecure deserialization
- 25 rules total with true-positive and true-negative test fixtures (50 fixture files)
- `--rules <language>` CLI option to enable packs (supports `all` for all packs)
- `extra_rules_dirs` support in `SemgrepScanner` for loading custom rule directories
- Rules bundled into Docker image via `COPY rules/ /app/rules/`
- `tests/test_custom_rules.py` validates YAML schema, required metadata (CWE, severity, category), fixture counts, and `resolve_rules_dirs()` helper

## CVE coverage per language

| Language | Rule | Related CVE/Pattern |
|----------|------|-------------------|
| Python/Django | ez-django-insecure-deserialization | CWE-502 (pickle RCE, cf. CVE-2020-13091) |
| Ruby/Rails | ez-rails-mass-assignment-permit-all | CWE-915 (cf. CVE-2013-0156 mass assignment) |
| Java/Spring | ez-spring-insecure-deserialization | CWE-502 (ObjectInputStream RCE, cf. CVE-2017-12149) |
| Node/Express | ez-express-insecure-deserialization | CWE-502 (node-serialize RCE, cf. CVE-2017-5941) |
| PHP/Laravel | ez-laravel-insecure-deserialization | CWE-502 (unserialize RCE, cf. CVE-2018-15133) |

## Test plan

- [x] `pytest tests/test_custom_rules.py` — 58/58 pass
- [x] `pytest tests/` — no new regressions (389 pass, pre-existing failures unchanged)
- [x] All 25 rule YAML files parse cleanly
- [ ] Docker build succeeds and image size ≤ 2 GB

Closes #17