### PR TITLE
chore: ignore generated Claude worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ update_phase5.py
 .gsd-id
 .mcp.json
 .bg-shell/
+.claude/worktrees/
 Thumbs.db
 *.code-workspace
 .env.*


### PR DESCRIPTION
## Summary\n- remove accidental tracked Claude worktree gitlink\n- ignore generated .claude/worktrees/ state while preserving tracked .claude commands/config files\n\n## Verification\n- Tree diff is limited to .claude/worktrees/ez-appsec deletion and .gitignore addition\n- Full suite previously passed on the equivalent cleaned local main merge: python3 -m pytest -q -> 727 passed, 21 skipped, 2 warnings\n\n## Stack\nMerge this into milestone/M002-eh86ge before merging the M002 milestone PR.