### PR TITLE
fix: normalize image findings and add scanner integration checks

### DIFF
--- a/.ez-appsec.yaml
+++ b/.ez-appsec.yaml
@@ -1,0 +1,8 @@
+# Project-local ez-appsec configuration.
+# Scanner integration fixtures intentionally contain vulnerable examples; they
+# are exercised by scripts/verify-scanner-integration.py and should not fail
+# repository self-scans or PR code-scanning checks.
+ignore:
+  - file_path: "tests/fixtures/scanners/**"
+    permanent: true
+    reason: "Intentional scanner integration fixtures with seeded vulnerabilities."

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -282,6 +282,12 @@ jobs:
             -v "$PWD:/workspace:ro" -w /workspace \
             ez-appsec:standard-rule-test scripts/verify-rule-fixtures.py
 
+      - name: Run scanner integration tests in standard image
+        run: |
+          docker run --rm --entrypoint python3 \
+            -v "$PWD:/workspace:ro" -w /workspace \
+            ez-appsec:standard-rule-test scripts/verify-scanner-integration.py
+
       - name: Test image functionality
         if: github.event_name != 'pull_request'
         run: |

--- a/github/dashboard/public/app-github.js
+++ b/github/dashboard/public/app-github.js
@@ -781,16 +781,30 @@ class GitHubDashboard {
     }
 
     getFilePath(vuln) {
-        if (vuln.location?.file) return vuln.location.file;
-        if (vuln.file) return vuln.file;
-        if (vuln.location?.dependency?.package?.name) {
-            return `dependency: ${vuln.location.dependency.package.name}`;
+        const file = vuln.location?.file ?? vuln.file;
+        if (typeof file === 'string' && file.trim()) return file;
+        if (file && typeof file === 'object') {
+            const fileName = file.file_name || file.name || file.path;
+            if (fileName) return fileName;
         }
+
+        const dependency = vuln.location?.dependency || vuln.dependency || {};
+        const packageInfo = dependency.package || {};
+        const packageName = packageInfo.name || dependency.package_name || vuln.package_name || vuln.artifact?.name;
+        const packageVersion = dependency.version || packageInfo.version || vuln.installed_version || vuln.artifact?.version;
+        if (packageName) {
+            return packageVersion ? `dependency: ${packageName}@${packageVersion}` : `dependency: ${packageName}`;
+        }
+
+        const image = vuln.image || vuln.container_image || vuln.location?.image || vuln.artifact?.locations?.[0]?.path;
+        if (image) return `image: ${image}`;
+
         return 'unknown';
     }
 
     getLineNumber(vuln) {
         if (vuln.location?.start_line) return vuln.location.start_line;
+        if (vuln.location?.file?.start_line) return vuln.location.file.start_line;
         if (vuln.line) return vuln.line;
         return null;
     }
@@ -798,7 +812,7 @@ class GitHubDashboard {
     getScannerName(vuln) {
         if (vuln.scanner?.name) return vuln.scanner.name;
         if (vuln.scanner?.id)   return vuln.scanner.id;
-        if (vuln.scanner)       return vuln.scanner;
+        if (typeof vuln.scanner === 'string') return vuln.scanner;
         return 'unknown';
     }
 

--- a/public/app.js
+++ b/public/app.js
@@ -159,24 +159,38 @@ class VulnerabilityDashboard {
     }
 
     getFilePath(vuln) {
-        if (vuln.location?.file) return vuln.location.file;
-        if (vuln.file) return vuln.file;
-        if (vuln.location?.dependency?.package?.name) {
-            return `dependency: ${vuln.location.dependency.package.name}`;
+        const file = vuln.location?.file ?? vuln.file;
+        if (typeof file === 'string' && file.trim()) return file;
+        if (file && typeof file === 'object') {
+            const fileName = file.file_name || file.name || file.path;
+            if (fileName) return fileName;
         }
+
+        const dependency = vuln.location?.dependency || vuln.dependency || {};
+        const packageInfo = dependency.package || {};
+        const packageName = packageInfo.name || dependency.package_name || vuln.package_name || vuln.artifact?.name;
+        const packageVersion = dependency.version || packageInfo.version || vuln.installed_version || vuln.artifact?.version;
+        if (packageName) {
+            return packageVersion ? `dependency: ${packageName}@${packageVersion}` : `dependency: ${packageName}`;
+        }
+
+        const image = vuln.image || vuln.container_image || vuln.location?.image || vuln.artifact?.locations?.[0]?.path;
+        if (image) return `image: ${image}`;
+
         return 'unknown';
     }
 
     getLineNumber(vuln) {
         if (vuln.location?.start_line) return vuln.location.start_line;
+        if (vuln.location?.file?.start_line) return vuln.location.file.start_line;
         if (vuln.line) return vuln.line;
         return null;
     }
 
     getScannerName(vuln) {
         if (vuln.scanner?.name) return vuln.scanner.name;
-        if (vuln.scanner?.id) return vuln.scanner.id;
-        if (vuln.scanner) return vuln.scanner;
+        if (vuln.scanner?.id)   return vuln.scanner.id;
+        if (typeof vuln.scanner === 'string') return vuln.scanner;
         return 'unknown';
     }
 

--- a/scripts/verify-scanner-integration.py
+++ b/scripts/verify-scanner-integration.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Verify scanner binary availability and wrapper parsing paths.
+
+This CI check is deterministic: it requires scanner binaries to be present in the
+standard image, then feeds representative scanner JSON through the real wrapper
+parsing code by patching subprocess.run at the wrapper boundary. That catches
+wrapper command/parsing/normalization regressions without depending on live
+vulnerability DB updates or external rule registry behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Tuple
+from unittest.mock import patch
+
+from ez_appsec.external_scanners import GitleaksScanner, GrypeScanner, KicsScanner, SemgrepScanner
+
+FIXTURES_ROOT = Path("tests/fixtures/scanners")
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _has_any(findings: Iterable[Dict[str, Any]], predicate: Callable[[Dict[str, Any]], bool]) -> bool:
+    return any(predicate(finding) for finding in findings)
+
+
+def _require_binary(binary: str, allow_missing: bool) -> bool:
+    if shutil.which(binary):
+        return True
+    message = f"{binary} is not installed"
+    if allow_missing:
+        print(f"SKIP {binary}: {message}")
+        return False
+    raise RuntimeError(message)
+
+
+def _assert_common_shape(scanner: str, findings: List[Dict[str, Any]]) -> None:
+    _assert(findings, f"{scanner} produced no findings")
+    for finding in findings:
+        _assert(finding.get("scanner"), f"{scanner} finding missing scanner: {finding}")
+        _assert(finding.get("severity"), f"{scanner} finding missing severity: {finding}")
+        _assert(finding.get("finding_id"), f"{scanner} finding missing finding_id: {finding}")
+        _assert(finding.get("schema_version") == "2", f"{scanner} finding missing schema v2 marker: {finding}")
+
+
+def _completed(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _write_json(path: str | Path, data: Any) -> None:
+    Path(path).write_text(json.dumps(data))
+
+
+def check_gitleaks(allow_missing: bool) -> str:
+    if not _require_binary("gitleaks", allow_missing):
+        return "skipped"
+
+    def fake_run(args: List[str], **_: Any) -> subprocess.CompletedProcess:
+        if args[:2] == ["gitleaks", "version"]:
+            return _completed(stdout="8.18.0")
+        if args[:2] == ["gitleaks", "detect"]:
+            out = args[args.index("--report-path") + 1]
+            _write_json(out, [{
+                "RuleID": "aws-access-token",
+                "Match": "AKIAIOSFODNN7EXAMPLE",
+                "File": "tests/fixtures/scanners/secrets/app.py",
+                "StartLine": 2,
+            }])
+            return _completed(returncode=1)
+        return _completed()
+
+    with patch("ez_appsec.external_scanners.subprocess.run", side_effect=fake_run):
+        findings = GitleaksScanner().scan(str(FIXTURES_ROOT / "secrets"))
+    _assert_common_shape("gitleaks", findings)
+    _assert(_has_any(findings, lambda f: f.get("category") in {"secret", "hardcoded-secret"} and f.get("rule_id") == "aws-access-token"),
+            f"gitleaks parser did not return expected secret fixture: {findings}")
+    return f"passed ({len(findings)} findings)"
+
+
+def check_kics(allow_missing: bool) -> str:
+    if not _require_binary("kics", allow_missing):
+        return "skipped"
+
+    def fake_run(args: List[str], **_: Any) -> subprocess.CompletedProcess:
+        if args[:2] == ["kics", "version"]:
+            return _completed(stdout="v2.1.20")
+        if args and args[0] == "kics" and "scan" in args:
+            out_dir = Path(args[args.index("-o") + 1])
+            out_dir.mkdir(parents=True, exist_ok=True)
+            _write_json(out_dir / "results.json", {
+                "queries": [{
+                    "queryName": "Security Group Allows unrestricted ingress",
+                    "description": "Security group permits SSH from the public internet",
+                    "severity": "HIGH",
+                    "results": [{
+                        "file": "tests/fixtures/scanners/iac/main.tf",
+                        "line": 5,
+                        "resource_type": "aws_security_group",
+                        "issue_type": "IncorrectValue",
+                        "expected_value": "restricted ingress",
+                        "actual_value": "0.0.0.0/0",
+                    }],
+                }]
+            })
+            return _completed()
+        return _completed()
+
+    with patch("ez_appsec.external_scanners.subprocess.run", side_effect=fake_run):
+        findings = KicsScanner().scan(str(FIXTURES_ROOT / "iac"))
+    _assert_common_shape("kics", findings)
+    _assert(_has_any(findings, lambda f: f.get("category") == "iac" and f.get("scanner") == "kics"),
+            f"kics parser did not return expected IaC fixture: {findings}")
+    return f"passed ({len(findings)} findings)"
+
+
+def check_grype(allow_missing: bool) -> str:
+    if not _require_binary("grype", allow_missing):
+        return "skipped"
+
+    def fake_run(args: List[str], **_: Any) -> subprocess.CompletedProcess:
+        if args[:2] == ["grype", "--version"] or args[:3] == ["grype", "db", "check"]:
+            return _completed(stdout="grype 0.74.0")
+        if args and args[0] == "grype" and "--file" in args:
+            out = args[args.index("--file") + 1]
+            _write_json(out, {
+                "matches": [{
+                    "vulnerability": {"id": "GHSA-whpj-8f3w-67p5", "severity": "Critical", "description": "vm2 sandbox escape"},
+                    "artifact": {"name": "vm2", "version": "3.9.17", "type": "npm"},
+                }]
+            })
+            return _completed()
+        return _completed()
+
+    with tempfile.TemporaryDirectory() as tmpdir, patch("ez_appsec.external_scanners.subprocess.run", side_effect=fake_run):
+        findings = GrypeScanner().scan(tmpdir)
+    _assert_common_shape("grype", findings)
+    _assert(_has_any(findings, lambda f: f.get("category") == "dependency" and "vm2" in str(f)),
+            f"grype parser did not return expected dependency fixture: {findings}")
+    return f"passed ({len(findings)} findings)"
+
+
+def check_semgrep(allow_missing: bool) -> str:
+    if not _require_binary("semgrep", allow_missing):
+        return "skipped"
+
+    def fake_run(args: List[str], **_: Any) -> subprocess.CompletedProcess:
+        if args[:2] == ["semgrep", "--version"]:
+            return _completed(stdout="1.99.0")
+        if args and args[0] == "semgrep" and "--output" in args:
+            out = args[args.index("--output") + 1]
+            _write_json(out, {
+                "results": [{
+                    "check_id": "ez-django-idor-get-parameter",
+                    "path": "tests/fixtures/scanners/semgrep/app.py",
+                    "start": {"line": 9},
+                    "extra": {"severity": "ERROR", "message": "IDOR via direct object lookup", "metadata": {"category": "security"}},
+                }]
+            })
+            return _completed()
+        return _completed()
+
+    with patch("ez_appsec.external_scanners.subprocess.run", side_effect=fake_run):
+        findings = SemgrepScanner(extra_rules_dirs=["rules/python"]).scan(str(FIXTURES_ROOT / "semgrep"))
+    _assert_common_shape("semgrep", findings)
+    _assert(_has_any(findings, lambda f: f.get("scanner") == "semgrep" and f.get("category") == "sast"),
+            f"semgrep parser did not return expected SAST fixture: {findings}")
+    return f"passed ({len(findings)} findings)"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--allow-missing-scanners",
+        action="store_true",
+        help="Skip scanners whose binaries are missing. Use only for local development; CI should fail on missing binaries.",
+    )
+    args = parser.parse_args()
+
+    checks = {
+        "gitleaks": check_gitleaks,
+        "kics": check_kics,
+        "grype": check_grype,
+        "semgrep": check_semgrep,
+    }
+    failures: List[str] = []
+    for name, check in checks.items():
+        try:
+            result = check(args.allow_missing_scanners)
+            print(f"{name}: {result}")
+        except Exception as exc:  # noqa: BLE001 - CLI summary should include all failed scanner checks
+            failures.append(f"{name}: {exc}")
+            print(f"{name}: FAILED: {exc}", file=sys.stderr)
+
+    if failures:
+        print("\nScanner integration failures:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/scanners/deps/package-lock.json
+++ b/tests/fixtures/scanners/deps/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "ez-appsec-grype-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ez-appsec-grype-fixture",
+      "version": "1.0.0",
+      "dependencies": {
+        "vm2": "3.9.17"
+      }
+    },
+    "node_modules/vm2": {
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQXzKs5v7yGx7+q7H4Q1bOGV7KvE3rQvVXQ8kk4A=="
+    }
+  },
+  "dependencies": {
+    "vm2": {
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQXzKs5v7yGx7+q7H4Q1bOGV7KvE3rQvVXQ8kk4A=="
+    }
+  }
+}

--- a/tests/fixtures/scanners/deps/package.json
+++ b/tests/fixtures/scanners/deps/package.json
@@ -1,0 +1,1 @@
+{"name":"ez-appsec-grype-fixture","version":"1.0.0","lockfileVersion":3,"dependencies":{"vm2":"3.9.17"}}

--- a/tests/fixtures/scanners/iac/main.tf.fixture
+++ b/tests/fixtures/scanners/iac/main.tf.fixture
@@ -1,0 +1,10 @@
+resource "aws_security_group" "allow_all" {
+  name = "allow_all_fixture"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/tests/fixtures/scanners/secrets/app.py
+++ b/tests/fixtures/scanners/secrets/app.py
@@ -1,0 +1,3 @@
+# Fixture intentionally contains fake credentials for scanner integration tests.
+AWS_ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"

--- a/tests/fixtures/scanners/semgrep/app.py
+++ b/tests/fixtures/scanners/semgrep/app.py
@@ -1,0 +1,13 @@
+# True positive: IDOR via direct object lookup without ownership check
+from django.http import JsonResponse
+
+
+class Invoice:
+    objects = None
+
+
+def get_invoice(request):
+    # ruleid: ez-django-idor-get-parameter
+    invoice_id = request.GET.get("id")
+    invoice = Invoice.objects.get(pk=invoice_id)
+    return JsonResponse({"total": invoice.total})

--- a/tests/test_dashboard_normalization.py
+++ b/tests/test_dashboard_normalization.py
@@ -1,0 +1,72 @@
+"""Regression tests for dashboard finding normalization."""
+
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required for dashboard JS tests")
+def test_grype_image_finding_normalizes_visible_dashboard_fields():
+    """Image/package findings should not render blank or object-shaped fields."""
+    app_js = Path("github/dashboard/public/app-github.js").read_text()
+    finding = {
+        "id": "CVE-2024-0001",
+        "name": "Vulnerable package: openssl",
+        "message": "openssl 3.0.0 has a known vulnerability",
+        "severity": "HIGH",
+        "scanner": {"id": "grype", "name": "Grype"},
+        "location": {
+            "file": {"file_name": "docker.io/library/alpine:3.18"},
+            "dependency": {
+                "package": {"name": "openssl"},
+                "version": "3.0.0",
+            },
+        },
+    }
+    dashboard_source = json.dumps(app_js + "\n" + "globalThis.GitHubDashboard = GitHubDashboard;")
+    finding_json = json.dumps(finding)
+    script = textwrap.dedent(
+        """
+        const vm = require('vm');
+        const source = __DASHBOARD_SOURCE__;
+        const context = {
+          console,
+          document: {
+            addEventListener: () => {},
+            createElement: () => ({
+              set textContent(value) {
+                this.innerHTML = String(value)
+                  .replace(/&/g, '&amp;')
+                  .replace(/</g, '&lt;')
+                  .replace(/>/g, '&gt;')
+                  .replace(/"/g, '&quot;');
+              },
+              innerHTML: '',
+            }),
+          },
+          window: { location: { href: 'http://localhost/' } },
+          URL,
+          URLSearchParams,
+          Blob: function() {},
+        };
+        vm.createContext(context);
+        vm.runInContext(source, context);
+        const dashboard = Object.create(context.GitHubDashboard.prototype);
+        dashboard.ownershipCache = {};
+        const normalized = dashboard.normalizeVulnerability(__FINDING_JSON__);
+        const card = dashboard.createVulnerabilityCard(normalized);
+        if (normalized.file !== 'docker.io/library/alpine:3.18') throw new Error(`bad file: ${normalized.file}`);
+        if (normalized.scanner !== 'Grype') throw new Error(`bad scanner: ${normalized.scanner}`);
+        if (!card.includes('docker.io/library/alpine:3.18')) throw new Error('card missing image location');
+        if (!card.includes('Grype')) throw new Error('card missing scanner');
+        if (card.includes('[object Object]')) throw new Error('card rendered object placeholder');
+        """
+    ).replace("__DASHBOARD_SOURCE__", dashboard_source).replace("__FINDING_JSON__", finding_json)
+
+    result = subprocess.run(["node", "-e", script], text=True, capture_output=True)
+
+    assert result.returncode == 0, result.stderr

--- a/web/app.js
+++ b/web/app.js
@@ -563,7 +563,7 @@ class VulnerabilityDashboard {
     getScannerName(vuln) {
         if (vuln.scanner?.name) return vuln.scanner.name;
         if (vuln.scanner?.id)   return vuln.scanner.id;
-        if (vuln.scanner)       return vuln.scanner;
+        if (typeof vuln.scanner === 'string') return vuln.scanner;
         return 'unknown';
     }
 


### PR DESCRIPTION
## Summary

- Fix dashboard normalization for object-shaped Grype/image finding locations so cards show meaningful image/package/file text instead of blank or object placeholders
- Add a dashboard regression test for image-style Grype findings
- Add tiny committed scanner fixtures for gitleaks, kics, grype, and semgrep
- Add `scripts/verify-scanner-integration.py` and run it inside the standard Docker image CI job

Fixes #69.
Closes #70.

## Verification

- `python3 -m pytest tests/test_dashboard_normalization.py tests/test_external_scanners.py -q` → 25 passed
- `python3 -m py_compile scripts/verify-scanner-integration.py`
- `python3 scripts/verify-scanner-integration.py --allow-missing-scanners` → locally skipped missing scanner binaries as expected
- `git diff --check`
- `python3 -m pytest tests/ -q` → 851 passed, 96 skipped, 2 warnings